### PR TITLE
Make uvicorn receive SIGTERM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,5 @@ RUN echo "GIT_COMMIT=\"$VCS_REF\"" > src/common/git_commit.py
 # FastAPI recommends running a single process service per docker container instance as below,
 # and scaling via adding more containers. If we need to run multiple processes, use guvicorn as
 # a process manger as described in the FastAPI docs
-ENTRYPOINT uvicorn --host 0.0.0.0 --port 5000 src.service.app:app
+ENTRYPOINT ["uvicorn", "--host", "0.0.0.0", "--port", "5000", "src.service.app:app"]
 

--- a/src/loaders/gtdb/gtdb_taxa_freq_loader.py
+++ b/src/loaders/gtdb/gtdb_taxa_freq_loader.py
@@ -91,8 +91,8 @@ def main():
                         help='GTDB taxonomy files')
 
     # Required flag argument
-    parser.add_argument('--load_version', required=True, type=str, nargs=1,
-                        help='GTDB load version')  # TODO parse from load_files name
+    parser.add_argument(
+        '--load_version', required=True, type=str, nargs=1, help='KBase load version')
 
     # Optional argument
     parser.add_argument('--kbase_collection', type=str, default='gtdb',


### PR DESCRIPTION
Never really understood why there were two syntaxes for ENTRYPOINT, and now I really don't understand since one of them will cause signals to not make it to your application.

With the ENTRYPOINT change the container now shuts down immediately rather than waiting for 10 seconds and getting a SIGKILL.