### PR TITLE
Handle authorization errors consistently

### DIFF
--- a/src/service/app.py
+++ b/src/service/app.py
@@ -3,19 +3,20 @@ API for the collections service.
 '''
 import os
 
-from src.common.git_commit import GIT_COMMIT
-from src.common.version import VERSION
 from datetime import datetime, timezone
 from fastapi import FastAPI, Depends, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError, HTTPException
 from fastapi.responses import JSONResponse
-from fastapi.security.http import HTTPBearer, HTTPBasicCredentials
+from fastapi.security.http import HTTPBasicCredentials
 from http.client import responses
 from pydantic import BaseModel, Field
 
+from src.common.git_commit import GIT_COMMIT
+from src.common.version import VERSION
 from src.service import kb_auth
 from src.service import errors
+from src.service.http_bearer import HTTPBearer
 
 
 # TODO LOGGING - log all write ops
@@ -54,7 +55,7 @@ async def build():
 
 @app.exception_handler(errors.CollectionError)
 async def handle_app_exception(r: Request, exc: errors.CollectionError):
-    if isinstance(exc, errors.InvalidTokenError):
+    if isinstance(exc, errors.AuthenticationError):
         status_code = status.HTTP_401_UNAUTHORIZED
     elif isinstance(exc, errors.UnauthorizedError):
         status_code = status.HTTP_403_FORBIDDEN

--- a/src/service/errors.py
+++ b/src/service/errors.py
@@ -25,6 +25,9 @@ class ErrorType(Enum):
     INVALID_TOKEN =          (10020, "Invalid token")  # noqa: E222 @IgnorePep8
     """ The token provided is not valid. """
 
+    INVALID_AUTH_HEADER =    (10030, "Invalid authentication header")  # noqa: E222 @IgnorePep8
+    """ The authentication header  is not valid. """
+
     UNAUTHORIZED =           (20000, "Unauthorized")  # noqa: E222 @IgnorePep8
     """ The user is not authorized to perform the requested action. """
 
@@ -58,7 +61,7 @@ class CollectionError(Exception):
     :ivar message: the message for this error.
     """
 
-    def __init__(self, error_type: ErrorType, message: Optional[str] = None) -> None:
+    def __init__(self, error_type: ErrorType, message: Optional[str] = None):
         '''
         Create a Collection error.
         :param error_type: the error type of this error.
@@ -73,16 +76,38 @@ class CollectionError(Exception):
         self.message: Optional[str] = message
 
 
-# leaving out a no token exception for now, I think FastAPI will deal with that.
-# might need some custom error handling to have a standard error structure
+class AuthenticationError(CollectionError):
+    """
+    Super class for authentication related errors.
+    """
+    def __init__(self, error_type: ErrorType, message: Optional[str] = None):
+        super().__init__(error_type, message)
 
 
-class InvalidTokenError(CollectionError):
+class MissingTokenError(AuthenticationError):
+    """
+    An error thrown when a token is required but absent.
+    """
+
+    def __init__(self, message: str = None):
+        super().__init__(ErrorType.NO_TOKEN, message)
+
+
+class InvalidAuthHeader(AuthenticationError):
+    """
+    An error thrown when an authorization header is invalid.
+    """
+
+    def __init__(self, message: str = None):
+        super().__init__(ErrorType.INVALID_AUTH_HEADER, message)
+
+
+class InvalidTokenError(AuthenticationError):
     """
     An error thrown when a user's token is invalid.
     """
 
-    def __init__(self, message: str = None) -> None:
+    def __init__(self, message: str = None):
         super().__init__(ErrorType.INVALID_TOKEN, message)
 
 
@@ -91,7 +116,7 @@ class UnauthorizedError(CollectionError):
     An error thrown when a user attempts a disallowed action.
     """
 
-    def __init__(self, message: str = None) -> None:
+    def __init__(self, message: str = None):
         super().__init__(ErrorType.UNAUTHORIZED, message)
 
 
@@ -100,7 +125,7 @@ class MissingParameterError(CollectionError):
     An error thrown when a required parameter is missing.
     """
 
-    def __init__(self, message: str = None) -> None:
+    def __init__(self, message: str = None):
         super().__init__(ErrorType.MISSING_PARAMETER, message)
 
 
@@ -109,7 +134,7 @@ class IllegalParameterError(CollectionError):
     An error thrown when a provided parameter is illegal.
     """
 
-    def __init__(self, message: str = None) -> None:
+    def __init__(self, message: str = None):
         super().__init__(ErrorType.ILLEGAL_PARAMETER, message)
 
 
@@ -118,7 +143,7 @@ class NoDataException(CollectionError):
     An error thrown when expected data does not exist.
     """
 
-    def __init__(self, error_type: ErrorType, message: str) -> None:
+    def __init__(self, error_type: ErrorType, message: str):
         super().__init__(error_type, message)
 
 
@@ -127,7 +152,7 @@ class NoSuchCollectionError(NoDataException):
     An error thrown when a collection does not exist.
     """
 
-    def __init__(self, message: str) -> None:
+    def __init__(self, message: str):
         super().__init__(ErrorType.NO_SUCH_COLLECTION, message)
 
 
@@ -136,5 +161,5 @@ class NoSuchCollectionVersionError(NoDataException):
     An error thrown when a collection version does not exist.
     """
 
-    def __init__(self, message: str) -> None:
+    def __init__(self, message: str):
         super().__init__(ErrorType.NO_SUCH_COLLECTION_VERSION, message)

--- a/src/service/http_bearer.py
+++ b/src/service/http_bearer.py
@@ -1,0 +1,39 @@
+"""
+Override of FastAPI's HTTPBearer class to allow for more informative errors
+"""
+
+from fastapi.security.http import HTTPBase, HTTPAuthorizationCredentials
+from fastapi.openapi.models import HTTPBearer as HTTPBearerModel
+from fastapi.security.utils import get_authorization_scheme_param
+from fastapi.requests import Request
+from typing import Optional
+from src.service import errors
+
+# Also, for some reason an exception handler for "Exception" wasn't trapping HTTPException classes
+# Modified from https://github.com/tiangolo/fastapi/blob/e13df8ee79d11ad8e338026d99b1dcdcb2261c9f/fastapi/security/http.py#L100
+
+_SCHEME = "Bearer"
+
+class HTTPBearer(HTTPBase):
+    def __init__(
+        self,
+        *,
+        bearerFormat: Optional[str] = None,
+        scheme_name: Optional[str] = None,
+        description: Optional[str] = None,
+    ):
+        self.model = HTTPBearerModel(bearerFormat=bearerFormat, description=description)
+        self.scheme_name = scheme_name or self.__class__.__name__
+
+    async def __call__(self, request: Request) -> HTTPAuthorizationCredentials:
+        authorization: str = request.headers.get("Authorization")
+        if not authorization:
+            raise errors.MissingTokenError("Authorization header required")
+        scheme, credentials = get_authorization_scheme_param(authorization)
+        if not (scheme and credentials):
+            raise errors.InvalidAuthHeader(
+                f"Authorization header requires {_SCHEME} scheme followed by token")
+        if scheme.lower() != _SCHEME.lower():
+            # don't put the received scheme in the error message, might be a token
+            raise errors.InvalidAuthHeader(f"Authorization header requires {_SCHEME} scheme")
+        return HTTPAuthorizationCredentials(scheme=scheme, credentials=credentials)


### PR DESCRIPTION
For unknown reasons the general error handler wasn't catching HTTPErrors, and in any case I wanted a more informative error than "auth didn't work"