### PR TITLE
Don't create app as a global

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,5 @@ RUN echo "GIT_COMMIT=\"$VCS_REF\"" > src/common/git_commit.py
 # FastAPI recommends running a single process service per docker container instance as below,
 # and scaling via adding more containers. If we need to run multiple processes, use guvicorn as
 # a process manger as described in the FastAPI docs
-ENTRYPOINT ["uvicorn", "--host", "0.0.0.0", "--port", "5000", "src.service.app:app"]
+ENTRYPOINT ["uvicorn", "--host", "0.0.0.0", "--port", "5000", "--factory", "src.service.app:create_app"]
 

--- a/src/service/app.py
+++ b/src/service/app.py
@@ -111,7 +111,7 @@ def format_error(
     return JSONResponse(status_code=status_code, content=jsonable_encoder(content))
 
 
-async def get_user(creds:HTTPBasicCredentials):
+async def get_user(app: FastAPI, creds:HTTPBasicCredentials):
     try:
         return await app.state.kb_auth.get_user(creds.credentials)
     except kb_auth.InvalidTokenError:
@@ -146,7 +146,7 @@ async def root():
 
 # TODO make a dependency that just returns the user & admin boolean
 @router.get("/whoami", response_model = WhoAmI)
-async def whoami(creds: HTTPBasicCredentials=Depends(authheader)):
-    admin, user = await get_user(creds)
+async def whoami(r: Request, creds: HTTPBasicCredentials=Depends(authheader)):
+    admin, user = await get_user(r.app, creds)
     return {"user": user.id, "is_service_admin": kb_auth.AdminPermission.FULL == admin}
 

--- a/test/src/service/app_test.py
+++ b/test/src/service/app_test.py
@@ -1,11 +1,11 @@
-# not sure I really like having a global app... but that's how python does it
-from src.service.app import app
+from src.service.app import create_app
 from fastapi.testclient import TestClient
 
 from conftest import assert_close_to_now
 
 
 def test_read_main():
+    app = create_app()
     client = TestClient(app)
     response = client.get("/")
     res = response.json()


### PR DESCRIPTION
Instead use a factory method. This has a couple of benefits:

1. The app isn't created on import
2. in the future we could potentially pass mocks into the create_app function to mock out app dependencies.