### PR TITLE
RE2022-52: Implement save / get collections in arango wrapper.

### DIFF
--- a/src/service/errors.py
+++ b/src/service/errors.py
@@ -46,6 +46,9 @@ class ErrorType(Enum):
     NO_SUCH_COLLECTION_VERSION = (40010, "No such collection version")  # noqa: E222 @IgnorePep8
     """ The requested collection version does not exist. """
 
+    COLLECTION_VERSION_EXISTS = (5000, "Collection version exists")  # noqa: E222 @IgnorePep8
+    """ The requested collection version already exists. """
+
     UNSUPPORTED_OP =         (100000, "Unsupported operation")  # noqa: E222 @IgnorePep8
     """ The requested operation is not supported. """
 
@@ -163,3 +166,12 @@ class NoSuchCollectionVersionError(NoDataException):
 
     def __init__(self, message: str):
         super().__init__(ErrorType.NO_SUCH_COLLECTION_VERSION, message)
+
+
+class CollectionVersionExistsError(CollectionError):
+    """
+    An error thrown when a collection version already exists.
+    """
+
+    def __init__(self, message: str):
+        super().__init__(ErrorType.COLLECTION_VERSION_EXISTS, message)

--- a/src/service/storage_arango.py
+++ b/src/service/storage_arango.py
@@ -2,9 +2,12 @@
 A storage system for collections based on an Arango backend.
 """
 
+import hashlib
+
 from aioarango.database import StandardDatabase
-from aioarango.exceptions import CollectionCreateError
-from src.service.models import SavedCollection
+from aioarango.exceptions import CollectionCreateError, DocumentInsertError
+from src.service import models
+from src.service import errors
 
 
 # service collection names that aren't shared with data loaders.
@@ -17,6 +20,10 @@ _FLD_KEY = "_key"
 _FLD_COLLECTION = "collection"
 _FLD_COLLECTION_ID = "collection_id"
 _FLD_COUNTER = "counter"
+
+_ARANGO_SPECIAL_KEYS = [_FLD_KEY, "_id", "_rev"]
+_ARANGO_ERR_NAME_EXISTS = 1207
+_ARANGO_ERR_UNIQUE_CONSTRAINT = 1210
 
 _QUERY_GET_NEXT_VERSION = f"""
     UPSERT {{{_FLD_KEY}: @{_FLD_COLLECTION_ID}}}
@@ -32,6 +39,7 @@ _QUERY_GET_NEXT_VERSION = f"""
 # Assume here that we're never going to make an alternate implementation of this interface.
 # Seems incredibly unlikely
 
+
 async def create_storage(
         db: StandardDatabase,
         create_collections_on_startup: bool = False):
@@ -45,16 +53,22 @@ async def create_storage(
         creation is useful for quickly standing up a test service.
     """
     if create_collections_on_startup:
-        # TODO DB create indexes and collections
         await _create_collection(db, _COLL_COUNTERS)  # no indexes necessary
+        await _create_collection(db, _COLL_ACTIVE)  # no indexes necessary yet
+        await _create_collection(db, _COLL_VERSIONS)
     else:
         await _check_collection_exists(db, _COLL_COUNTERS)
-        # TODO DB check collections and indexes exist
+        await _check_collection_exists(db, _COLL_ACTIVE)
+        await _check_collection_exists(db, _COLL_VERSIONS)
+    vercol = db.collection(_COLL_VERSIONS)
+    await vercol.add_persistent_index([models.FIELD_COLLECTION_ID, models.FIELD_VER_NUM])
     return ArangoStorage(db)
+
 
 async def _check_collection_exists(db: StandardDatabase, col_name: str):
     if not await db.has_collection(col_name):
         raise ValueError(f"Collection {col_name} does not exist")
+
 
 async def _create_collection(db: StandardDatabase, col_name: str):
     """
@@ -63,8 +77,24 @@ async def _create_collection(db: StandardDatabase, col_name: str):
     try:
         await db.create_collection(col_name)
     except CollectionCreateError as e:
-        if not e.error_code == 1207:  # duplicate name error code
+        if e.error_code != _ARANGO_ERR_NAME_EXISTS:
             raise  # if collection exists, ignore, otherwise raise
+
+
+def _md5(contents: str):
+    return hashlib.md5(contents.encode('utf-8')).hexdigest()
+
+
+def _version_key(collection_id: str, ver_tag: str):
+    return _md5(f"{collection_id}_{ver_tag}")
+
+
+# modifies doc in place
+def _remove_arango_keys(doc: dict):
+    for k in _ARANGO_SPECIAL_KEYS:
+        doc.pop(k, None)
+    return doc
+
 
 class ArangoStorage:
     """
@@ -74,7 +104,7 @@ class ArangoStorage:
     def __init__(self, db: StandardDatabase):
         self._db = db
         # TODO DB make some sort of pluginish system for data products
-        # TODO NOW document endpoint in new endpointsfile (in /docs/endpoint.md)
+        # TODO ENDPOINTS document endpoint in new endpointsfile (in /docs/endpoint.md)
 
     async def get_next_version(self, collection_id: str) -> int:
         """ Get the next available version number for a collection. """
@@ -86,18 +116,76 @@ class ArangoStorage:
         verdoc = await cur.next()
         return verdoc[_FLD_COUNTER]
 
-    async def save_collection(self, collection: SavedCollection, active: bool = False) -> None:
-        # check that active user & date are set if active = true
-        pass
+    async def save_collection_version(self, collection: models.SavedCollection) -> None:
+        """
+        Save a version of a collection. The version is not active.
+        The caller is expected to use the `get_next_version` method to get a version number for
+        the collection.
+        """
+        doc = collection.dict()
+        # ver_tag is pretty unconstrained so MD5 to get rid of any weird characters
+        doc[_FLD_KEY] = _version_key(collection.id, collection.ver_tag)
+        col = self._db.collection(_COLL_VERSIONS)
+        try:
+            await col.insert(doc)
+        except DocumentInsertError as e:
+            if e.error_code == _ARANGO_ERR_UNIQUE_CONSTRAINT:
+                raise errors.CollectionVersionExistsError(
+                    f"There is already a collection {collection.id} "
+                    + f"with version {collection.ver_tag}")
+            else:
+                raise e
 
-    async def get_collections_active(self) -> list[SavedCollection]:
-        pass
+    async def save_collection_active(self, collection: models.ActiveCollection) -> None:
+        """
+        Save a collection, making it active.
+        The caller is expected to retrive a collection from a `get_collection_version_by_*`
+        method, update it to an active collection, and save it here.
+        """
+        doc = collection.dict()
+        doc[_FLD_KEY] = collection.id
+        col = self._db.collection(_COLL_ACTIVE)
+        await col.insert(doc, overwrite=True)
 
-    async def get_collection_active(self, collection_id: str) -> SavedCollection:
-        pass
+    async def get_collections_active(self) -> list[models.ActiveCollection]:
+        pass # TODO COLL implement list colls
 
-    async def get_collection_version_by_tag(self, collection_id: str, ver_tag: str):
-        pass
+    async def get_collection_active(self, collection_id: str) -> models.ActiveCollection:
+        """ Get an active collection. """
+        col = self._db.collection(_COLL_ACTIVE)
+        doc = await col.get(collection_id)
+        if doc is None:
+            raise errors.NoSuchCollectionError(
+                f"There is no active collection {collection_id}")
+        return models.ActiveCollection.construct(**_remove_arango_keys(doc))
 
-    async def get_collection_version_by_num(self, collection_id: str, ver_num: int):
-        pass
+    async def get_collection_version_by_tag(self, collection_id: str, ver_tag: str
+    ) -> models.SavedCollection:
+        """ Get a collection version by its version tag. """
+        col = self._db.collection(_COLL_VERSIONS)
+        doc = await col.get(_version_key(collection_id, ver_tag))
+        if doc is None:
+            raise errors.NoSuchCollectionVersionError(
+                f"No collection {collection_id} with version tag {ver_tag}")
+        # if we really want to be careful here we could check that the id and tag match
+        # the returned doc, since theoretically it might be possible to construct an id and tag
+        # that collide with the md5 of another id and tag. YAGNI for now.
+        return models.SavedCollection.construct(**_remove_arango_keys(doc))
+
+    async def get_collection_version_by_num(self, collection_id: str, ver_num: int
+    ) -> models.SavedCollection:
+        """ Get a collection version by its version number. """
+        col = self._db.collection(_COLL_VERSIONS)
+        cur = await col.find({
+            models.FIELD_COLLECTION_ID: collection_id,
+            models.FIELD_VER_NUM: ver_num
+        })
+        if cur.count() > 1:
+            raise ValueError(
+                f"Found more than 1 document in the db for collection {collection_id} "
+                + f"and version number {ver_num}")
+        if cur.count() < 1:
+            raise errors.NoSuchCollectionVersionError(
+                f"No collection {collection_id} with version number {ver_num}")
+        doc = await cur.next()
+        return models.SavedCollection.construct(**_remove_arango_keys(doc))


### PR DESCRIPTION
Manual tests below. Also tested error paths, but tests are omitted for length.

```
In [1]: from src.service.storage_arango import create_storage

In [2]: from src.service.models import SavedCollection, ActiveCollection, DataPr
   ...: oduct

In [3]: import aioarango

In [4]: cli = aioarango.ArangoClient(hosts='http://localhost:8529')

In [5]: db = await cli.db("collections_test")

In [6]: arst = await create_storage(db, create_collections_on_startup=True)

In [7]: sc = SavedCollection(id="foo", name="bar", ver_tag="foobar", ver_src="r2
   ...: 07", data_products=[DataProduct(product="prod", version="pver")], ver_nu
   ...: m=65, date_create="iso8601ts", user_create="kbhelp")

In [8]: await arst.save_collection_version(sc)

In [9]: await arst.get_collection_version_by_tag("foo", "foobar")
Out[9]: SavedCollection(id='foo', name='bar', ver_tag='foobar', ver_src='r207', desc=None, data_products=[{'product': 'prod', 'version': 'pver'}], ver_num=65, date_create='iso8601ts', user_create='kbhelp')

In [10]: await arst.get_collection_version_by_num("foo", 65)
Out[10]: SavedCollection(id='foo', name='bar', ver_tag='foobar', ver_src='r207', desc=None, data_products=[{'product': 'prod', 'version': 'pver'}], ver_num=65, date_create='iso8601ts', user_create='kbhelp')

In [11]: scdoc = sc.dict()

In [12]: scdoc['date_active'] = 'iso8601date2'

In [13]: scdoc['user_active'] = 'someuser'

In [14]: ac = ActiveCollection.construct(**scdoc)

In [15]: ac
Out[15]: ActiveCollection(id='foo', name='bar', ver_tag='foobar', ver_src='r207', desc=None, data_products=[{'product': 'prod', 'version': 'pver'}], ver_num=65, date_create='iso8601ts', user_create='kbhelp', date_active='iso8601date2', user_active='someuser')

In [16]: await arst.save_collection_active(ac)

In [17]: await arst.get_collection_active("foo")
Out[17]: ActiveCollection(id='foo', name='bar', ver_tag='foobar', ver_src='r207', desc=None, data_products=[{'product': 'prod', 'version': 'pver'}], ver_num=65, date_create='iso8601ts', user_create='kbhelp', date_active='iso8601date2', user_active='someuser')

In [18]: ac.name = "bar2"

In [19]: await arst.save_collection_active(ac)

In [20]: await arst.get_collection_active("foo")
Out[20]: ActiveCollection(id='foo', name='bar2', ver_tag='foobar', ver_src='r207', desc=None, data_products=[{'product': 'prod', 'version': 'pver'}], ver_num=65, date_create='iso8601ts', user_create='kbhelp', date_active='iso8601date2', user_active='someuser')
```