### PR TITLE
Add a /collections endpoint to the service.

### DIFF
--- a/collections_config.toml.jinja
+++ b/collections_config.toml.jinja
@@ -27,3 +27,8 @@ admin_roles_full = "{{ KBCOLL_KBASE_AUTH2_ADMIN_ROLES or ""}}"
 # If the service is behind a reverse proxy that rewrites the service path, that path needs
 # to be defined here in order for the OpenAPI documentation to function.
 root_path = "{{ KBCOLL_SERVICE_ROOT_PATH or "" }}"
+
+# Set to "true" to have the service create the database and collections on startup. Generally
+# this should be left as "false" since the database admins will want to create collections with
+# their sharding preferences.
+create_db_on_startup = "{{ KBCOLL_CREATE_DB_ON_STARTUP or "false" }}"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       - KBCOLL_ARANGO_DB=collections_test
       - KBASE_AUTH_URL=https://ci.kbase.us/services/auth
       - KBCOLL_KBASE_AUTH2_ADMIN_ROLES=COLLECTIONS_SERVICE_ADMIN
+      - KBCOLL_CREATE_DB_ON_STARTUP=true
 
   # Arangodb server in cluster mode
   arangodb:

--- a/src/service/config.py
+++ b/src/service/config.py
@@ -29,6 +29,8 @@ class CollectionsServiceConfig:
     service_root_path: str  | None - if the service is behind a reverse proxy that rewrites the
         service path, the path to the service. The path is required in order for the OpenAPI
         documentation to function.
+    create_db_on_startup: bool - True if the service should create the database on startup.
+        Generally this should be false to allow admins to set up sharding as desired.
     """
 
     def __init__(self, config_file: BinaryIO):
@@ -59,6 +61,8 @@ class CollectionsServiceConfig:
         self.auth_full_admin_roles = _get_list_string(config, _SEC_AUTH, "admin_roles_full")
 
         self.service_root_path = _get_string_optional(config, _SEC_SERVICE, "root_path")
+        self.create_db_on_startup = _get_string_optional(
+            config, _SEC_SERVICE, "create_db_on_startup") == "true"
 
     def print_config(self, output: TextIO):
         """
@@ -78,6 +82,7 @@ class CollectionsServiceConfig:
             f"Authentication URL: {self.auth_url}\n",
             f"Authentication full admin roles: {self.auth_full_admin_roles}\n",
             f"Service root path: {self.service_root_path}\n",
+            f"Create database on start: {self.create_db_on_startup}\n"
             "*** End Service Configuration ***\n\n"
         ])
 

--- a/src/service/models.py
+++ b/src/service/models.py
@@ -153,7 +153,7 @@ class ActiveCollection(SavedCollection):
     date_active: str = Field(
         example="2022-10-07T17:58:53.188698+00:00",
         description="The date the collection version was set as the active version in "
-            + "ISO8601 format. Absent if not the active version"
+            + "ISO8601 format."
     )
     user_active: str = Field(
         example="kbasehelp",


### PR DESCRIPTION
Sets up the DB connection as is now required.

```
In [1]: from src.service.storage_arango import create_storage

In [2]: from src.service.models import SavedCollection, ActiveCollection, DataPr
   ...: oduct

In [3]: import aioarango

In [4]: cli = aioarango.ArangoClient(hosts='http://localhost:8529')

In [5]: db = await cli.db("collections_test")

In [6]: arst = await create_storage(db, create_collections_on_startup=True)

In [7]: ac = ActiveCollection(id="foo", name="bar", ver_tag="foobar", ver_src="r
   ...: 207", data_products=[DataProduct(product="prod", version="pver")], ver_n
   ...: um=65, date_create="iso8601ts", user_create="kbhelp", date_active="iso86
   ...: 01ts2", user_active="user2")

In [8]: await arst.save_collection_active(ac)

In [9]: ac.name = 'whoo'

In [10]: ac.id = 'whee'

In [11]: await arst.save_collection_active(ac)

In [12]: import requests

In [13]: requests.get("http://localhost:5000/collections").json()
Out[13]:
[{'id': 'foo',
  'name': 'bar',
  'ver_tag': 'foobar',
  'ver_src': 'r207',
  'desc': None,
  'data_products': [{'product': 'prod', 'version': 'pver'}],
  'ver_num': 65,
  'date_create': 'iso8601ts',
  'user_create': 'kbhelp',
  'date_active': 'iso8601ts2',
  'user_active': 'user2'},
 {'id': 'whee',
  'name': 'whoo',
  'ver_tag': 'foobar',
  'ver_src': 'r207',
  'desc': None,
  'data_products': [{'product': 'prod', 'version': 'pver'}],
  'ver_num': 65,
  'date_create': 'iso8601ts',
  'user_create': 'kbhelp',
  'date_active': 'iso8601ts2',
  'user_active': 'user2'}]
```