### PR TITLE
Prevent collection collisions

### DIFF
--- a/src/service/data_product_specs.py
+++ b/src/service/data_product_specs.py
@@ -5,10 +5,13 @@ To add a data product to the service, create a new module in the data_products d
 and define a DataProductSpec. Import it in this file and add it to the DATA_PRODUCTS variable.
 The data product routes will be added to the OpenAPI UI in the same order as the first
 item in the `tags` field of the router.
+
+Note that "builtin" is a reserved ID for data products.
 """
 
 from src.service.data_products.common import DataProductSpec
 from src.service.data_products import taxa_count
+
 
 DATA_PRODUCTS: list[DataProductSpec] = [
     taxa_count.TAXA_COUNT_SPEC,

--- a/src/service/data_products/common.py
+++ b/src/service/data_products/common.py
@@ -55,6 +55,12 @@ class DataProductSpec(BaseModel):
     in the `tags` argument.
     """
 
+    @validator("router")
+    def _check_router_tags(cls, v):
+        if not v.tags:
+            raise ValueError("router must have at least one tag")
+        return v
+
     class Config:
         arbitrary_types_allowed = True
 

--- a/src/service/data_products/taxa_count.py
+++ b/src/service/data_products/taxa_count.py
@@ -79,3 +79,6 @@ async def get_ranks(r: Request, collection_id: str = PATH_VALIDATOR_COLLECTION_I
             + f"{collection_id} collection load version {load_ver}")
     doc = await cur.next()
     return Ranks(data=doc[names.FLD_TAXA_COUNT_RANKS])
+
+
+# TODO DATAPROD add counts endpoint


### PR DESCRIPTION
Two data products sharing the same collection names would be bad