### PR TITLE
Drop skip max to 10000

### DIFF
--- a/src/service/data_products/genome_attributes.py
+++ b/src/service/data_products/genome_attributes.py
@@ -101,7 +101,7 @@ async def get_ranks(
     skip: int | None = Query(
         default=None,
         ge=0,
-        le=100000,
+        le=10000,
         example=1000,
         description="The number of records to skip, default 0"
     ),


### PR DESCRIPTION
Paging through records with skip & limit is O(n^2), so
10000 = 100M ops
100000 = 10B ops

Also, 10K is the ElasticSearch default, so we're in good company with that value.