### PR TITLE
Don't check sort field before query

### DIFF
--- a/src/service/data_products/genome_attributes.py
+++ b/src/service/data_products/genome_attributes.py
@@ -120,7 +120,6 @@ async def get_ranks(
     # Otherwise we need indexes for every sort
     store = app_state.get_storage(r)
     load_ver = await get_load_version(store, collection_id, ID, load_ver_override, user)
-    await _check_sort_field(store, collection_id, load_ver, sort_on)
     aql = f"""
     FOR d IN @@{_FLD_COL_NAME}
         FILTER d.{names.FLD_COLLECTION_ID} == @{_FLD_COL_ID}
@@ -145,29 +144,7 @@ async def get_ranks(
     async for d in cur:
         # not clear there's any benefit to creating a bunch of TaxaCount objects here
         ret.append(remove_collection_keys(remove_arango_keys(d)))
-    return {_FLD_SKIP: skip, _FLD_LIMIT: limit, "data": ret}
-
-
-async def _check_sort_field(store: ArangoStorage, collection_id: str, load_ver: str, field: str):
-    if field == names.FLD_GENOME_ATTRIBS_GENOME_NAME:
-        return
-    aql = f"""
-    FOR d IN @@{_FLD_COL_NAME}
-        FILTER d.{names.FLD_COLLECTION_ID} == @{_FLD_COL_ID}
-        FILTER d.{names.FLD_LOAD_VERSION} == @{_FLD_COL_LV}
-        LIMIT 1
-        RETURN d
-    """
-    bind_vars = {
-        f"@{_FLD_COL_NAME}": names.COLL_GENOME_ATTRIBS,
-        _FLD_COL_ID: collection_id,
-        _FLD_COL_LV: load_ver,
-    }
-    cur = await store.aql().execute(aql, bind_vars=bind_vars)
-    doc = await cur.next()
-    if not doc:
-        return  # no data, so no sorting.
-    if field not in doc:
+    if ret and sort_on not in ret[0]: 
         raise errors.IllegalParameterError(
-            f"No such field for collection {collection_id} load version {load_ver}: {field}")
-    
+            f"No such field for collection {collection_id} load version {load_ver}: {sort_on}")
+    return {_FLD_SKIP: skip, _FLD_LIMIT: limit, "data": ret}


### PR DESCRIPTION
It's punishing everyone who gets the sort field right with an extra query. Just check the sort field after the regular query (since arango doesn't complain) and throw an error then.