### PR TITLE
RE2022-78: Add matchers endpoint

### DIFF
--- a/src/service/data_product_specs.py
+++ b/src/service/data_product_specs.py
@@ -18,6 +18,3 @@ DATA_PRODUCTS: list[DataProductSpec] = [
     genome_attributes.GENOME_ATTRIBS_SPEC
 ]
 """ Set of data products the service supports. """
-
-
-# TODO DATAPROD add markdown docs explaining how to create data products

--- a/src/service/data_products/genome_attributes.py
+++ b/src/service/data_products/genome_attributes.py
@@ -36,6 +36,9 @@ GENOME_ATTRIBS_SPEC = DataProductSpec(
                     names.FLD_COLLECTION_ID,
                     names.FLD_LOAD_VERSION,
                     names.FLD_GENOME_ATTRIBS_KBASE_GENOME_ID,
+                    # Since this is the default sort option (see below), we specify an index
+                    # for fast sorts since every time the user hits the UI for the first time
+                    # or without specifying a sort order it'll sort on this field
                 ]
             ]
         )
@@ -100,7 +103,7 @@ _FLD_LIMIT = "limit"
         + "collection to collection.\n\n "
         + "Authentication is not required unless overriding the load version, in which case "
         + "service administration permissions are required.")
-async def get_ranks(
+async def get_genome_attributes(
     r: Request,
     collection_id: str = PATH_VALIDATOR_COLLECTION_ID,
     sort_on: str = Query(

--- a/src/service/matcher_registry.py
+++ b/src/service/matcher_registry.py
@@ -1,0 +1,17 @@
+"""
+A registry of matchers available in the service.
+"""
+
+# very simple for now, just add your matcher here
+# could add an actual registry method at some point, but seems like overkill for now
+
+from src.service.matchers import lineage_matcher
+
+_MATCHERS = [lineage_matcher.MATCHER]
+
+MATCHERS = {}
+
+for m in _MATCHERS:
+    if m.id in MATCHERS:
+        raise ValueError(f"matchers have the same id: {m.id}")
+    MATCHERS[m.id] = m

--- a/src/service/matchers/common_models.py
+++ b/src/service/matchers/common_models.py
@@ -1,0 +1,45 @@
+"""
+Data structures common to all matchers
+"""
+
+from pydantic import BaseModel, Field, validator
+from typing import Any
+
+
+class Matcher(BaseModel):
+    id: str = Field(
+        example="gtdb_lineage",
+        description="Matches assemblies and genomes via the GTDB lineage.",
+        regex="^[a-z_]+$",
+    )
+    types: list[str] = Field(
+        # TODO MATCHERS validate types against workspace on startup
+        # It'd be nice to specify type versions as well, but KBase has essentially jettisoned
+        # that idea
+        example=["KBaseGenomes.Genome", "KBaseGenomeAnnotations.Assembly"],
+        description="The KBase types against which the matcher operates.",
+    )
+    description: str = Field(
+        example="Matches assemblies and genomes via the GTDB lineage",
+        description="A free text description of the matcher.",
+    )
+    user_parameters: dict[str, Any] | None = Field(
+        example={
+            'title': 'LineageMatcherParams',
+            'type': 'object',
+            'properties': {'lineage_rank': {'title': 'Lineage Rank', 'type': 'string'}},
+            'required': ['lineage_rank'],
+        },
+        description=
+            "JSONSchema describing the parameters of the matcher provided by the user, if any",
+    )
+    collection_parameters: dict[str, Any] | None = Field(
+        example={
+            'title': 'LineageMatcherParams',
+            'type': 'object',
+            'properties': {'gtdb_version': {'title': 'Gtdb Version', 'type': 'string'}},
+            'required': ['gtdb_version'],
+        },
+        description="JSONSchema describing parameters provided in the collection document" +
+            "when adding a matcher to a collection, if any",
+    )

--- a/src/service/matchers/lineage_matcher.py
+++ b/src/service/matchers/lineage_matcher.py
@@ -1,0 +1,23 @@
+"""
+Matches assemblies and genomes to collections based on the GTDB lineage string.
+"""
+
+from pydantic import BaseModel, Field
+
+from src.service.matchers.common_models import Matcher
+
+class LineageMatcherCollectionParameters(BaseModel):
+    "Parameters for the GTDB lineage matcher."
+    gtdb_version: str = Field(
+        example="207.0",
+        description="The GTDB version of the collection in which the matcher is installed."
+    )
+
+
+MATCHER = Matcher(
+    id="gtdb_lineage",
+    description="Matches based on the GTDB lineage string.",
+    types=["KBaseGenomes.Genome", "KBaseGenomeAnnotations.Assembly"],
+    user_parameters=None, # TODO MATCHERS add rank parameter when supporting rank based matching
+    collection_parameters=LineageMatcherCollectionParameters.schema()
+)

--- a/src/service/routes_collections.py
+++ b/src/service/routes_collections.py
@@ -9,8 +9,10 @@ from src.common.version import VERSION
 from src.service import app_state
 from src.service import errors
 from src.service import kb_auth
+from src.service import matcher_registry
 from src.service import models
 from src.service.http_bearer import KBaseHTTPBearer, KBaseUser
+from src.service.matchers.common_models import Matcher
 from src.service.routes_common import PATH_VALIDATOR_COLLECTION_ID, err_on_control_chars
 from src.service.storage_arango import ArangoStorage
 from src.service.timestamp import timestamp
@@ -87,6 +89,10 @@ class WhoAmI(BaseModel):
     is_service_admin: bool = Field(example=False)
 
 
+class MatcherList(BaseModel):
+    data: list[Matcher]
+
+
 class CollectionsList(BaseModel):
     data: list[models.ActiveCollection]
 
@@ -123,6 +129,15 @@ async def whoami(user: KBaseUser=Depends(_AUTH)):
         "user": user.user.id,
         "is_service_admin": kb_auth.AdminPermission.FULL == user.admin_perm
     }
+
+
+@ROUTER_GENERAL.get(
+    "/matchers/",
+    response_model=MatcherList,
+    description="List all matchers available in the service."
+)
+async def matchers():
+    return {"data": list(matcher_registry.MATCHERS.values())}
 
 
 @ROUTER_COLLECTIONS.get("/collectionids/", response_model = CollectionIDs)


### PR DESCRIPTION
Returns information about matchers avialable in the service. Useful for people adding matchers to collections