### PR TITLE
RE2022-98: Add data product match structure & arango methods

### DIFF
--- a/src/common/storage/collection_and_field_names.py
+++ b/src/common/storage/collection_and_field_names.py
@@ -26,6 +26,9 @@ FLD_LOAD_VERSION = "load_ver"
 FLD_MATCH_ID = "match_id"
 """ The name of the key that has a match ID as its value. """
 
+FLD_INTERNAL_MATCH_ID = "internal_match_id"
+""" The name of the key that has an internal match ID as its value. """
+
 # Collections
 
 COLLECTION_PREFIX = "kbcoll_"
@@ -51,6 +54,9 @@ COLL_SRV_ACTIVE = _SRV_PREFIX + "active"
 
 COLL_SRV_MATCHES = _SRV_PREFIX + "matches"
 """ A collection holding matches to Collections. """
+
+COLL_SRV_MATCHES_DATA_PRODUCTS = COLL_SRV_MATCHES + "_data_prods"
+""" A collection holding the status of calculating secondary data products for matches. """
 
 ## Data product collections
 

--- a/src/common/storage/db_doc_conversions.py
+++ b/src/common/storage/db_doc_conversions.py
@@ -12,7 +12,7 @@ def taxa_node_count_to_doc(
     kbase_collection: str,
     load_version: str,
     taxa_count: TaxaNodeCount,
-    match_id: str = None
+    internal_match_id: str = None
 ) -> dict[str, str | int]:
     """
     Convert a taxa node count to a document suitable for storage in a document based database.
@@ -20,10 +20,10 @@ def taxa_node_count_to_doc(
     kbase_collection - the name of the KBase collection with which the data is associated
     load_version - the load version of the data set
     taxa_count - the taxa count information to convert
-    match_id - the match ID of the related match, if any
+    internal_match_id - the internal match ID of the related match, if any
     """
     full_rank = GTDB_RANK_ABBREV_TO_FULL_NAME[taxa_count.rank]
-    match_id_str = f"{match_id}_" if match_id else ""
+    match_id_str = f"{internal_match_id}_" if internal_match_id else ""
     doc = {
         names.FLD_ARANGO_KEY: md5_string(
             f"{kbase_collection}_{load_version}_{match_id_str}_{full_rank}_{taxa_count.name}"
@@ -33,7 +33,6 @@ def taxa_node_count_to_doc(
         names.FLD_TAXA_COUNT_RANK: full_rank,
         names.FLD_TAXA_COUNT_NAME: taxa_count.name,
         names.FLD_TAXA_COUNT_COUNT: taxa_count.count,
+        names.FLD_INTERNAL_MATCH_ID: internal_match_id,
     }
-    if match_id:
-        doc[names.FLD_MATCH_ID] = match_id
     return doc

--- a/src/service/matchers/lineage_matcher.py
+++ b/src/service/matchers/lineage_matcher.py
@@ -37,6 +37,10 @@ class GTDBLineageMatcherCollectionParameters(BaseModel):
     )
 
 
+def _process_match(match_id: str, pstorage: PickleableDependencies, args: list[list[str]]):
+    asyncio.run(_process_match_async(match_id, pstorage, args))
+
+
 async def _process_match_async(
     match_id: str,
     pstorage: PickleableDependencies,
@@ -51,10 +55,6 @@ async def _process_match_async(
         await storage.update_match_state(match_id, models.MatchState.FAILED, now_epoch_millis())
     finally:
         await arangoclient.close()
-
-
-def _process_match(match_id: str, pstorage: PickleableDependencies, args: list[list[str]]):
-    asyncio.run(_process_match_async(match_id, pstorage, args))
 
 
 class GTDBLineageMatcher(Matcher):

--- a/test/src/loaders/genome_collection/compute_genome_taxa_count_test.py
+++ b/test/src/loaders/genome_collection/compute_genome_taxa_count_test.py
@@ -37,8 +37,10 @@ def _exam_count_result_file(result_file, expected_docs_length, expected_doc_keys
 
     versions = set([d['load_ver'] for d in data])
     collections = set([d['coll'] for d in data])
+    internal_match_ids = set([d['internal_match_id'] for d in data])
     assert versions == {expected_load_version}
     assert collections == {expected_collection}
+    assert internal_match_ids == {None}
 
 
 def _exam_rank_result_file(result_file, expected_load_version, expected_collection, expected_ranks_inorder):
@@ -76,7 +78,7 @@ def test_create_json_default(setup_and_teardown):
     _exe_command(command)
 
     expected_docs_length = 5420
-    expected_doc_keys = {'_key', 'coll', 'load_ver', 'rank', 'name', 'count'}
+    expected_doc_keys = {'_key', 'coll', 'load_ver', 'rank', 'name', 'count', 'internal_match_id'}
     expected_collection = 'GTDB'
     _exam_count_result_file(result_file, expected_docs_length, expected_doc_keys,
                             load_version, expected_collection)
@@ -100,7 +102,7 @@ def test_create_json_option_input(setup_and_teardown):
     _exe_command(command)
 
     expected_docs_length = 5420
-    expected_doc_keys = {'_key', 'coll', 'load_ver', 'rank', 'name', 'count'}
+    expected_doc_keys = {'_key', 'coll', 'load_ver', 'rank', 'name', 'count', 'internal_match_id'}
     _exam_count_result_file(result_file, expected_docs_length, expected_doc_keys,
                             load_version, kbase_collections)
     expected_ranks_inorder = ['domain', 'phylum', 'class', 'order', 'family', 'genus', 'species']


### PR DESCRIPTION
Also make internal_match_id a standard field for taxa counts so the matches can be stored in the same collection

Also also add a bulk update helper method which will be needed when inserting taxa_count records