### PR TITLE
Small bugfixes & simplifications

### DIFF
--- a/src/service/data_products/genome_attributes.py
+++ b/src/service/data_products/genome_attributes.py
@@ -322,8 +322,9 @@ async def perform_match(match_id: str, storage: ArangoStorage, lineages: list[st
     # Could save some bandwidth here buy adding a method to just get the internal ID
     # Microoptimization, wait until it's a problem
     match = await storage.get_match_full(match_id)
-    coll = await storage.get_collection_active(match.collection_id)  # support non-active cols?
-    load_ver = {dp.product: dp for dp in coll.data_products}[ID].version
+    # use version number to avoid race conditions with activating collections
+    coll = await storage.get_collection_version_by_num(match.collection_id, match.collection_ver)
+    load_ver = {dp.product: dp.version for dp in coll.data_products}[ID]
     filtered_lineages = set()  # remove duplicates
     for lin in lineages:
         # TODO MATCHERS reverse look up the abbreviation from the rank when rank input is done

--- a/src/service/data_products/genome_attributes.py
+++ b/src/service/data_products/genome_attributes.py
@@ -370,8 +370,7 @@ async def perform_match(match_id: str, storage: ArangoStorage, lineages: list[st
 
 async def process_match_documents(
     storage: ArangoStorage,
-    collection_id: str,
-    load_version: str,
+    collection: models.SavedCollection,
     internal_match_id: str,
     acceptor: Callable[[dict[str, Any]], None],
     fields: list[str] | None = None,
@@ -387,10 +386,13 @@ async def process_match_documents(
     fields - which fields are required from the database documents. Fewer fields means less
         bandwidth consumed.
     """
+    load_ver = {d.product: d.version for d in collection.data_products}.get(ID)
+    if not load_ver:
+        raise ValueError(f"The collection does not have a {ID} data product")
     bind_vars = {
         f"@{_FLD_COL_NAME}": names.COLL_GENOME_ATTRIBS,
-        _FLD_COL_ID: collection_id,
-        _FLD_COL_LV: load_version,
+        _FLD_COL_ID: collection.id,
+        _FLD_COL_LV: load_ver,
         "internal_match_id": internal_match_id,
         "keep": fields,
     }

--- a/src/service/data_products/taxa_count.py
+++ b/src/service/data_products/taxa_count.py
@@ -311,10 +311,11 @@ async def _process_match(match_id: str, pstorage: app_state.PickleableDependenci
     try:
         # TODO MATCHERS start a heartbeat that updates a time stamp on the arango match document
         #   - be sure to stop when match execution is done
-        # TODO MATCHERS should use collection version here and in genome match to avoid
-        # race condition
         match = await storage.get_match_full(match_id)
-        coll = await storage.get_collection_active(match.collection_id)  # support non-active cols?
+        # use version number to avoid race conditions with activating collections
+        coll = await storage.get_collection_version_by_num(
+            match.collection_id, match.collection_ver
+        )
         load_ver = {dp.product: dp.version for dp in coll.data_products}[ID]
         # Right now this is hard coded to use the GTDB lineage, which is the only choice we
         # have. Might need to expand in future for other count strategies.

--- a/src/service/data_products/taxa_count.py
+++ b/src/service/data_products/taxa_count.py
@@ -2,7 +2,6 @@
 The taxa_count data product, which provides taxa counts for a collection at each taxonomy rank.
 """
 
-import asyncio
 import logging
 from fastapi import APIRouter, Request, Depends, Path, Query
 from pydantic import BaseModel, Field
@@ -307,13 +306,7 @@ async def _query(
     return ret
 
 
-def _process_match(match_id: str, pstorage: app_state.PickleableDependencies, args: list):
-    # no args necessary
-    # TODO MATCHER could probably build this into the match runner class
-    asyncio.run(_process_match_async(match_id, pstorage))
-
-
-async def _process_match_async(match_id: str, pstorage: app_state.PickleableDependencies):
+async def _process_match(match_id: str, pstorage: app_state.PickleableDependencies, args: list):
     arangoclient, storage = await pstorage.get_storage()
     try:
         # TODO MATCHERS start a heartbeat that updates a time stamp on the arango match document
@@ -322,7 +315,7 @@ async def _process_match_async(match_id: str, pstorage: app_state.PickleableDepe
         # race condition
         match = await storage.get_match_full(match_id)
         coll = await storage.get_collection_active(match.collection_id)  # support non-active cols?
-        load_vers = {dp.product: dp.version for dp in coll.data_products}
+        load_ver = {dp.product: dp.version for dp in coll.data_products}[ID]
         # Right now this is hard coded to use the GTDB lineage, which is the only choice we
         # have. Might need to expand in future for other count strategies.
         # Maybe a collection parameter, which would be available from the collection data structure
@@ -330,13 +323,12 @@ async def _process_match_async(match_id: str, pstorage: app_state.PickleableDepe
         count = GTDBTaxaCount()
         await genome_attributes.process_match_documents(
             storage,
-            coll.id,
-            load_vers[genome_attributes.ID],
+            coll,
             match.internal_match_id,
             lambda doc: count.add(doc[names.FLD_GENOME_ATTRIBS_GTDB_LINEAGE]),
             fields=[names.FLD_GENOME_ATTRIBS_GTDB_LINEAGE]
         )
-        docs = [taxa_node_count_to_doc(coll.id, load_vers[ID], tc, match.internal_match_id)
+        docs = [taxa_node_count_to_doc(coll.id, load_ver, tc, match.internal_match_id)
                 for tc in count
                 ]
         # May need to batch this?

--- a/src/service/data_products/taxa_count.py
+++ b/src/service/data_products/taxa_count.py
@@ -353,4 +353,3 @@ async def _process_match(match_id: str, pstorage: app_state.PickleableDependenci
             # otherwise not much to do, something went very wrong
     finally:
         await arangoclient.close()
-

--- a/src/service/matchers/lineage_matcher.py
+++ b/src/service/matchers/lineage_matcher.py
@@ -2,7 +2,6 @@
 Matches assemblies and genomes to collections based on the GTDB lineage string.
 """
 
-import asyncio
 import logging
 
 from pydantic import BaseModel, Field
@@ -37,11 +36,7 @@ class GTDBLineageMatcherCollectionParameters(BaseModel):
     )
 
 
-def _process_match(match_id: str, pstorage: PickleableDependencies, args: list[list[str]]):
-    asyncio.run(_process_match_async(match_id, pstorage, args))
-
-
-async def _process_match_async(
+async def _process_match(
     match_id: str,
     pstorage: PickleableDependencies,
     args: list[list[str]]


### PR DESCRIPTION
1. Make the MatchProcess class handle the asyncio stuff rather than making the implementer of the matcher do it. Now they just have to implement an async function with the right args.
2. Simplify the API for running through a genome attributes match slightly.
3. Fix a potential, although unlikely, race condition when matching
4. Fix a bug when a `None` or empty fields list is supplied to `process_match_documents`