### PR TITLE
Refactor dependencies into class

### DIFF
--- a/collections_config.toml.jinja
+++ b/collections_config.toml.jinja
@@ -33,16 +33,6 @@ root_path = "{{ KBCOLL_SERVICE_ROOT_PATH or "" }}"
 # their sharding preferences.
 create_db_on_startup = "{{ KBCOLL_CREATE_DB_ON_STARTUP or "false" }}"
 
-# Set to "true" to not connect to any external services except for authorization,
-# including the database. This will cause all calls to the service that require external
-# service access to fail but is useful for quickly checking OpenAPI documentation
-# or general methods that don't access external services.
-# The service can be run via:
-# docker run --env-file <your .env file> --publish 5000:5000 <image hash>
-# Example:
-# docker run --env-file collections.env --publish 5000:5000 3b6523ebf6b8
-dont_connect_to_external_services = "{{ KBCOLL_DONT_CONNECT_TO_EXT_SERVICES or "false" }}"
-
 [Service_Dependencies]
 
 # The URL of a KBase workspace service

--- a/src/service/app.py
+++ b/src/service/app.py
@@ -16,6 +16,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from src.common.version import VERSION
 from src.service import app_state
 from src.service import errors
+from src.service import matcher_registry
 from src.service import models_errors
 from src.service.config import CollectionsServiceConfig
 from src.service.data_product_specs import DATA_PRODUCTS
@@ -75,11 +76,16 @@ def create_app(noop=False):
     app.include_router(ROUTER_COLLECTIONS_ADMIN)
 
     async def build_app_wrapper():
-        await app_state.build_app(app, cfg, DATA_PRODUCTS.values())
+        await app_state.build_app(
+            app,
+            cfg,
+            DATA_PRODUCTS.values(),
+            matcher_registry.MATCHERS.values()
+        )
     app.add_event_handler("startup", build_app_wrapper)
 
     async def clean_app_wrapper():
-        await app_state.clean_app(app)
+        await app_state.get_app_state_from_app(app).destroy()
     app.add_event_handler("shutdown", clean_app_wrapper)
     return app
 

--- a/src/service/config.py
+++ b/src/service/config.py
@@ -3,7 +3,7 @@ A configuration parser for the collections service. The configuration is expecte
 (https://toml.io/en/) format.
 """
 
-import tomli  # TODO swap to stdlib in py 3.11
+import tomli  # TODO CODE swap to stdlib in py 3.11
 from typing import Optional, BinaryIO, TextIO
 
 _SEC_ARANGO = "Arango"
@@ -32,11 +32,6 @@ class CollectionsServiceConfig:
         documentation to function.
     create_db_on_startup: bool - True if the service should create the database on startup.
         Generally this should be false to allow admins to set up sharding as desired.
-    dont_connect_to_external_services: bool - True if the service should not connect to
-        any external services except for authorization, including the database. This
-        will cause all calls to the service that require external service access to fail but is
-        useful for quickly checking OpenAPI documentation or general methods that don't
-        access the external services.
 
     workspace_url: str - the URL of the KBase Workspace service.
     """
@@ -72,8 +67,6 @@ class CollectionsServiceConfig:
         self.service_root_path = _get_string_optional(config, _SEC_SERVICE, "root_path")
         self.create_db_on_startup = _get_string_optional(
             config, _SEC_SERVICE, "create_db_on_startup") == "true"
-        self.dont_connect_to_external_services = _get_string_optional(
-            config, _SEC_SERVICE, "dont_connect_to_external_services") == "true"
 
         self.workspace_url = _get_string_required(config, _SEC_SERVICE_DEPS, "workspace_url")
 
@@ -96,8 +89,6 @@ class CollectionsServiceConfig:
             f"Authentication full admin roles: {self.auth_full_admin_roles}\n",
             f"Service root path: {self.service_root_path}\n",
             f"Create database on start: {self.create_db_on_startup}\n"
-            f"Don't connect to external services: "
-                + f"{self.dont_connect_to_external_services}\n"
             f"Workspace URL: {self.workspace_url}\n"
             "*** End Service Configuration ***\n\n"
         ])

--- a/src/service/data_products/genome_attributes.py
+++ b/src/service/data_products/genome_attributes.py
@@ -179,14 +179,14 @@ async def get_genome_attributes(
     # sorting only works here since we expect the largest collection to be ~300K records and
     # we have a max limit of 1000, which means sorting is O(n log2 1000).
     # Otherwise we need indexes for every sort
-    store = app_state.get_storage(r)
+    store = app_state.get_app_state(r).arangostorage
     internal_match_id = None
     if match_id:
         if not user:
             raise errors.UnauthorizedError("Authentication is required if a match ID is supplied")
         coll = await store.get_collection_active(collection_id)
         load_ver = get_load_ver_from_collection(coll, ID)
-        ws = app_state.get_workspace(r, user.token)
+        ws = app_state.get_app_state(r).get_workspace_client(user.token)
         match = await match_retrieval.get_match_full(
             match_id,
             user.user.id,

--- a/src/service/http_bearer.py
+++ b/src/service/http_bearer.py
@@ -60,7 +60,7 @@ class KBaseHTTPBearer(HTTPBase):
             # don't put the received scheme in the error message, might be a token
             raise errors.InvalidAuthHeader(f"Authorization header requires {_SCHEME} scheme")
         try:
-            admin_perm, user = await app_state.get_kbase_auth(request).get_user(credentials)
+            admin_perm, user = await app_state.get_app_state(request).auth.get_user(credentials)
         except kb_auth.InvalidTokenError:
             raise errors.InvalidTokenError()
         return KBaseUser(user, admin_perm, credentials)


### PR DESCRIPTION
While working on the dead process restart feature, I ran into a couple problems:

* `matcher_registry` imports were winding up everywhere in order to get matchers to rerun match processes. This lead to circular imports all over as well.
* I was having to pass in storage, workspace, pickleable deps, and matcher dependencies to some of the new methods, which was making the method signatures huge.

To fix this I refactored dependency handling into a state class that can be passed around and used to get dependencies as needed. I added the matchers to that class so that the matcher registry only needs to be imported at the top level of the app and the matchers passed into the state builder, which breaks the import loops.