### PR TITLE
RE2022-85: Add DB methods for adding, getting, and removing deleted matches

### DIFF
--- a/src/common/storage/collection_and_field_names.py
+++ b/src/common/storage/collection_and_field_names.py
@@ -55,6 +55,9 @@ COLL_SRV_ACTIVE = _SRV_PREFIX + "active"
 COLL_SRV_MATCHES = _SRV_PREFIX + "matches"
 """ A collection holding matches to Collections. """
 
+COLL_SRV_MATCHES_DELETED = COLL_SRV_MATCHES + "_deleted"
+""" A collection holding matches in the deleted state. """
+
 COLL_SRV_MATCHES_DATA_PRODUCTS = COLL_SRV_MATCHES + "_data_prods"
 """ A collection holding the status of calculating secondary data products for matches. """
 

--- a/src/service/models.py
+++ b/src/service/models.py
@@ -42,6 +42,7 @@ FIELD_DATA_PRODUCTS_PRODUCT = "product"
 FIELD_MATCHERS = "matchers"
 FIELD_MATCHERS_MATCHER = "matcher"
 FIELD_MATCH_LAST_ACCESS = "last_access"
+FIELD_MATCH_INTERNAL_MATCH_ID = "internal_match_id"
 FIELD_MATCH_HEARTBEAT = "heartbeat"
 FIELD_MATCH_USER_PERMS = "user_last_perm_check"
 FIELD_MATCH_STATE = "match_state"
@@ -371,6 +372,14 @@ class InternalMatch(MatchVerbose):
         description="A mapping of user name to the last time their permissions to view the "
             + "match was checked in Unix epoch milliseconds. Used to determine when to recheck "
             + "permissions for a user."
+    )
+
+
+class DeletedMatch(InternalMatch):
+    """ A match in the deleted state, waiting for permanent deletion. """
+    deleted: int = Field(
+        example=1674243789870,
+        description="Milliseconds since the Unix epoch at the point the match was deleted."
     )
 
 


### PR DESCRIPTION
```python
In [1]: from src.service.data_product_specs import DATA_PRODUCTS

In [2]: from src.service.storage_arango import ArangoStorage

In [3]: from src.service import models

In [4]: import aioarango

In [5]: cli = aioarango.ArangoClient(hosts='http://localhost:8529')

In [6]: db = await cli.db("collections_test", username="root", password="foobar"
   ...: )

In [7]: dps = {dp.data_product: dp.db_collections for dp in DATA_PRODUCTS.values
   ...: ()}

In [8]: arst = await ArangoStorage.create(db, dps)

In [9]: match_id = "ff1d36301008ace844e77b8a7698273c"

In [10]: # got above from match already existing in DB

In [11]: mtch = await arst.get_match_full(match_id)

In [12]: mtch
Out[12]: InternalMatch(match_id='ff1d36301008ace844e77b8a7698273c', matcher_id='gtdb_lineage', collection_id='GTDB', collection_ver=7, user_parameters={'rank': 'genus'}, collection_parameters={'gtdb_version': '207.0'}, match_state=<MatchState.COMPLETE: 'complete'>, upas=['68953/6/1', '68953/7/1', '68953/8/1'], matches=['RS_GCF_000017565.1', 'GB_GCA_000281995.2', 'RS_GCF_900108355.1', 'RS_GCF_002902965.1', 'RS_GCF_002157295.1', 'RS_GCF_900168175.1', 'RS_GCF_902833685.1', 'RS_GCF_002157285.1', 'RS_GCF_003330805.1', 'RS_GCF_002157305.1', 'RS_GCF_900167965.1', 'GB_GCA_002245905.1', 'RS_GCF_000265115.1', 'RS_GCF_900230235.1', 'RS_GCF_900168075.1'], internal_match_id='becd5989-96de-4e0c-a869-994b80a16a8d', wsids=[68953], created=1676856781614, last_access=1676946089815, heartbeat=1676857482000, match_state_updated=1676946029866, user_last_perm_check={'gaprice': 1676946034843})

In [13]: internal_match_id = mtch.internal_match_id

In [14]: last_access = mtch.last_access

In [15]: await arst.remove_match(match_id, 42)
Out[15]: False

In [16]: # match still in DB per aardvark

In [17]: await arst.remove_match(match_id, last_access)
Out[17]: True

In [18]: # match gone

In [19]: await arst.save_match(mtch)
Out[19]:
(Match(match_id='ff1d36301008ace844e77b8a7698273c', matcher_id='gtdb_lineage', collection_id='GTDB', collection_ver=7, user_parameters={'rank': 'genus'}, collection_parameters={'gtdb_version': '207.0'}, match_state='complete'),
 False)

In [20]: md = mtch.dict()

In [21]: md['deleted'] = 100

In [22]: delmtch = models.DeletedMatch(**md)

In [23]: delmtch
Out[23]: DeletedMatch(match_id='ff1d36301008ace844e77b8a7698273c', matcher_id='gtdb_lineage', collection_id='GTDB', collection_ver=7, user_parameters={'rank': 'genus'}, collection_parameters={'gtdb_version': '207.0'}, match_state=<MatchState.COMPLETE: 'complete'>, upas=['68953/6/1', '68953/7/1', '68953/8/1'], matches=['RS_GCF_000017565.1', 'GB_GCA_000281995.2', 'RS_GCF_900108355.1', 'RS_GCF_002902965.1', 'RS_GCF_002157295.1', 'RS_GCF_900168175.1', 'RS_GCF_902833685.1', 'RS_GCF_002157285.1', 'RS_GCF_003330805.1', 'RS_GCF_002157305.1', 'RS_GCF_900167965.1', 'GB_GCA_002245905.1', 'RS_GCF_000265115.1', 'RS_GCF_900230235.1', 'RS_GCF_900168075.1'], internal_match_id='becd5989-96de-4e0c-a869-994b80a16a8d', wsids={68953}, created=1676856781614, last_access=1676946089815, heartbeat=1676857482000, match_state_updated=1676946029866, user_last_perm_check={'gaprice': 1676946034843}, deleted=100)

In [24]: await arst.add_deleted_match(delmtch)

In [25]: await arst.get_deleted_match(internal_match_id)
Out[25]: DeletedMatch(match_id='ff1d36301008ace844e77b8a7698273c', matcher_id='gtdb_lineage', collection_id='GTDB', collection_ver=7, user_parameters={'rank': 'genus'}, collection_parameters={'gtdb_version': '207.0'}, match_state=<MatchState.COMPLETE: 'complete'>, upas=['68953/6/1', '68953/7/1', '68953/8/1'], matches=['RS_GCF_000017565.1', 'GB_GCA_000281995.2', 'RS_GCF_900108355.1', 'RS_GCF_002902965.1', 'RS_GCF_002157295.1', 'RS_GCF_900168175.1', 'RS_GCF_902833685.1', 'RS_GCF_002157285.1', 'RS_GCF_003330805.1', 'RS_GCF_002157305.1', 'RS_GCF_900167965.1', 'GB_GCA_002245905.1', 'RS_GCF_000265115.1', 'RS_GCF_900230235.1', 'RS_GCF_900168075.1'], internal_match_id='becd5989-96de-4e0c-a869-994b80a16a8d', wsids=[68953], created=1676856781614, last_access=1676946089815, heartbeat=1676857482000, match_state_updated=1676946029866, user_last_perm_check={'gaprice': 1676946034843}, deleted=100)

In [26]: delmtch.deleted = 200

In [29]: await arst.add_deleted_match(delmtch)

In [30]: await arst.get_deleted_match(internal_match_id)
Out[30]: DeletedMatch(match_id='ff1d36301008ace844e77b8a7698273c', matcher_id='gtdb_lineage', collection_id='GTDB', collection_ver=7, user_parameters={'rank': 'genus'}, collection_parameters={'gtdb_version': '207.0'}, match_state=<MatchState.COMPLETE: 'complete'>, upas=['68953/6/1', '68953/7/1', '68953/8/1'], matches=['RS_GCF_000017565.1', 'GB_GCA_000281995.2', 'RS_GCF_900108355.1', 'RS_GCF_002902965.1', 'RS_GCF_002157295.1', 'RS_GCF_900168175.1', 'RS_GCF_902833685.1', 'RS_GCF_002157285.1', 'RS_GCF_003330805.1', 'RS_GCF_002157305.1', 'RS_GCF_900167965.1', 'GB_GCA_002245905.1', 'RS_GCF_000265115.1', 'RS_GCF_900230235.1', 'RS_GCF_900168075.1'], internal_match_id='becd5989-96de-4e0c-a869-994b80a16a8d', wsids=[68953], created=1676856781614, last_access=1676946089815, heartbeat=1676857482000, match_state_updated=1676946029866, user_last_perm_check={'gaprice': 1676946034843}, deleted=200)

In [31]: await arst.remove_deleted_match(internal_match_id, 42)
Out[31]: False

In [32]: # still in DB

In [33]: await arst.remove_deleted_match(internal_match_id, last_access)
Out[33]: True

In [34]: # gone

In [35]:
```