### PR TITLE
RE2022-85: Add match deletion framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ gtdb_attribs.jsonl
 gtdb_attribs2.jsonl
 .DS_Store
 .vscode/settings.json
+collections_config.toml

--- a/src/service/match_deletion.py
+++ b/src/service/match_deletion.py
@@ -1,0 +1,101 @@
+"""
+Routines to safely delete matches and clean up match data in the collections system
+"""
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from datetime import datetime
+
+from src.service import app_state
+from src.service import processing
+
+async def _move_matches_to_deletion(deps: app_state.PickleableDependencies, match_age_ms: int):
+    print("_move_matches_to_deletion", datetime.now(), match_age_ms, flush=True)
+    # Find matches with last_access < now - age
+    # Save deleted match
+    # Delete std match IF last_access hasn't changed
+    #   If it has, punt and let _delete_matches clean up (or a future run of _move)
+
+
+async def _delete_matches(deps: app_state.PickleableDependencies):
+    print("_delete_matches", datetime.now(), flush=True)
+    # * Find deleted matches
+    # * If standard match exists (e.g. server went down)
+    #   * if last_access is the same as the deleted match, delete the standard match
+    #     (requiring last_access to be the same when deleting) and continue
+    #     * if last_access changes during that time punt
+    #   * otherwise, delete the deleted match if last_access is the same as previous and punt
+    #     either way
+    # * For each data product in the collection
+    #   * remove all secondary data for each DP
+    #   * remove the DP match doc
+    # * Remove the deleted match doc
+
+
+class MatchCleanup:
+    """
+    Move matches into a deleted state and when the deletion state change is complete
+    execute the delection.
+    """
+    
+    def __init__(
+        self,
+        pickleable_dependencies: app_state.PickleableDependencies,
+        interval_sec: int = 1 * 24 * 60 * 60,
+        jitter_sec: int | None = 60 * 60,
+        match_age_ms: int = 7 * 24 * 60 * 60 * 1000,
+    ):
+        """
+        Create the match deleter.
+
+        pickelable_dependences - the pickleable system dependencies.
+        interval_sec - how often, in seconds, the deletion scanner should run
+        jitter_sec - start the job at the interval time +/- up to `jitter_sec` seconds. This allows
+            for different service instances to randomize the start time, making running
+            the deletion processes at the same time less likely. `jitter_sec` should be scaled
+            appropriately given the value of `interval_sec`.
+        match_age_ms - how many epoch milliseconds must have elapsed since the last time a
+            match was accesed before it can be deleted. This should be set high
+            enough so that any in flight requests using the match, either match processors
+            (including data product match processors) or match views, can complete before the
+            match is moved to a deleted state.
+        """
+        self._deps = pickleable_dependencies
+        self._age = match_age_ms
+        self._schd = BackgroundScheduler(daemon=True)
+        self._schd.start(paused=True)
+        self._started = False
+        self._schd.add_job(
+            self._move_matches_to_deletion,
+            "interval",
+            seconds=interval_sec,
+            jitter=jitter_sec,
+        )
+        self._schd.add_job(
+            self._delete_matches,
+            "interval",
+            seconds=interval_sec,
+            jitter=jitter_sec,
+        )
+
+    def _move_matches_to_deletion(self):
+        processing.run_async_process(_move_matches_to_deletion, [self._deps, self._age])
+
+    def _delete_matches(self):
+        processing.run_async_process(_delete_matches, [self._deps])
+
+    def start(self):
+        """
+        Start the match deletion process.
+        """
+        if self._started:
+            raise ValueError("already started")
+        self._schd.resume()
+        self._started = True
+
+    def stop(self):
+        """
+        Stop the match deletion process.
+        """
+        self._schd.pause()
+        self._started = False


### PR DESCRIPTION
Next: fill in the match deletion code based on the (very) psuedocode

```python
In [1]: from src.service.match_deletion import MatchCleanup

In [2]: from src.service import app_state

In [3]: def mc():
   ...:     # there should be error checking to avoid this, but helpful
   ...:     # to be able to fake the inputs for now
   ...:     pd = app_state.PickleableDependencies(None, None)
   ...:     mc = MatchCleanup(pd, 10, 5, 42)
   ...:     mc.start()
   ...:     return mc
   ...:

In [5]: matchc = mc()

In [6]: _delete_matches 2023-02-25 21:49:44.102995
_move_matches_to_deletion 2023-02-25 21:49:44.978632 42
_delete_matches 2023-02-25 21:49:55.938965
_move_matches_to_deletion 2023-02-25 21:49:58.006959 42
_delete_matches 2023-02-25 21:50:08.150818
_move_matches_to_deletion 2023-02-25 21:50:09.783336 42
_delete_matches 2023-02-25 21:50:19.743918
_move_matches_to_deletion 2023-02-25 21:50:22.080325 42
In [6]: matchc.stop()

In [7]: matchc = mc()

In [8]: _move_matches_to_deletion 2023-02-25 21:52:51.822788 42
_delete_matches 2023-02-25 21:52:53.190784
In [8]: matchc.start()
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[8], line 1
----> 1 matchc.start()

File ~/github/kbase/collections/src/service/match_deletion.py:92, in MatchCleanup.start(self)
     88 """
     89 Start the match deletion process.
     90 """
     91 if self._started:
---> 92     raise ValueError("already started")
     93 self._schd.resume()
     94 self._started = True

ValueError: already started

In [9]: mat_delete_matches 2023-02-25 21:53:03.239105
matchc.st_move_matches_to_deletion 2023-02-25 21:53:04.858272 42
In [9]: matchc.stop()

In [10]: matchc.start()

Run time of job "MatchCleanup._move_matches_to_deletion (trigger: interval[0:00:10], next run at: 2023-02-25 21:55:29 PST)" was missed by 0:00:08.971956
Run time of job "MatchCleanup._delete_matches (trigger: interval[0:00:10], next run at: 2023-02-25 21:55:25 PST)" was missed by 0:00:12.522389
Execution of job "MatchCleanup._delete_matches (trigger: interval[0:00:10], next run at: 2023-02-25 21:55:25 PST)" skipped: maximum number of running instances reached (1)
In [11]: _move_matches_to_deletion 2023-02-25 21:55:30.238822 42
_delete_matches 2023-02-25 21:55:39.962903
_move_matches_to_deletion 2023-02-25 21:55:44.858931 42
matchs_delete_matches 2023-02-25 21:55:51.367440
In [11]: matchc.stop()
```