### PR TITLE
Refactor to break import loops

### DIFF
--- a/src/service/_app_state_build_storage.py
+++ b/src/service/_app_state_build_storage.py
@@ -1,0 +1,55 @@
+import aioarango
+import asyncio
+import sys
+
+from src.service.config import CollectionsServiceConfig
+from src.service.data_products.common_models import DBCollection
+from src.service.storage_arango import ArangoStorage, ARANGO_ERR_NAME_EXISTS
+
+
+async def build_storage(
+    cfg: CollectionsServiceConfig,
+    data_products: dict[str, list[DBCollection]],
+) -> tuple[aioarango.ArangoClient, ArangoStorage]:
+    cli = aioarango.ArangoClient(hosts=cfg.arango_url)
+    try:
+        if cfg.create_db_on_startup:
+            sysdb = await _get_arango_db(cli, "_system", cfg)
+            try:
+                await sysdb.create_database(cfg.arango_db)
+            except aioarango.exceptions.DatabaseCreateError as e:
+                if e.error_code != ARANGO_ERR_NAME_EXISTS:  # ignore, db exists
+                    raise
+        db = await _get_arango_db(cli, cfg.arango_db, cfg)
+        storage = await ArangoStorage.create(
+            db,
+            data_products=data_products,
+            create_collections_on_startup=cfg.create_db_on_startup
+        )
+        return cli, storage
+    except:
+        await cli.close()
+        raise
+
+
+async def _get_arango_db(cli: aioarango.ArangoClient, db: str, cfg: CollectionsServiceConfig
+) -> aioarango.database.StandardDatabase:
+    err = None
+    for t in [1, 2, 5, 10, 30]:
+        try:
+            if cfg.arango_user:
+                rdb = await cli.db(
+                    db, verify=True, username=cfg.arango_user, password=cfg.arango_pwd)
+            else:
+                rdb = await cli.db(db, verify=True)
+            return rdb
+        except aioarango.exceptions.ServerConnectionError as e:
+            err = e
+            print(  f"Failed to connect to Arango database at {cfg.arango_url}\n"
+                  + f"    Error: {err}\n"
+                  + f"    Waiting for {t}s and retrying db connection"
+            )
+            sys.stdout.flush()
+            # TODO CODE both time.sleep() and this block SIGINT. How to fix?
+            await asyncio.sleep(t)
+    raise ValueError(f"Could not connect to Arango at {cfg.arango_url}") from err

--- a/src/service/app.py
+++ b/src/service/app.py
@@ -19,7 +19,7 @@ from src.service import errors
 from src.service import matcher_registry
 from src.service import models_errors
 from src.service.config import CollectionsServiceConfig
-from src.service.data_product_specs import DATA_PRODUCTS
+from src.service import data_product_specs
 from src.service.routes_collections import (
     ROUTER_GENERAL,
     ROUTER_COLLECTIONS,
@@ -71,7 +71,8 @@ def create_app(noop=False):
     app.include_router(ROUTER_GENERAL)
     app.include_router(ROUTER_COLLECTIONS)
     app.include_router(ROUTER_MATCHES)
-    for dp in sorted(DATA_PRODUCTS.values(), key=lambda dp: str(dp.router.tags[0])):
+    for dp in sorted(data_product_specs.get_data_products(),
+                     key=lambda dp: str(dp.router.tags[0])):
         app.include_router(dp.router, prefix="/collections/{collection_id}/data_products")
     app.include_router(ROUTER_COLLECTIONS_ADMIN)
 
@@ -79,7 +80,7 @@ def create_app(noop=False):
         await app_state.build_app(
             app,
             cfg,
-            DATA_PRODUCTS.values(),
+            data_product_specs.get_data_products(),
             matcher_registry.MATCHERS.values()
         )
     app.add_event_handler("startup", build_app_wrapper)

--- a/src/service/app_state.py
+++ b/src/service/app_state.py
@@ -5,132 +5,17 @@ All functions assume that the application state has been appropriately initializ
 calling the build_app() method
 """
 
-import aioarango
-import asyncio
-import sys
-
 from fastapi import FastAPI, Request
+from src.service._app_state_build_storage import build_storage
+from src.service.app_state_data_structures import CollectionsState
 from src.service.clients.workspace_client import Workspace
 from src.service.config import CollectionsServiceConfig
-from src.service.data_products.common_models import DataProductSpec, DBCollection
+from src.service.data_products.common_models import DataProductSpec
 from src.service.matchers.common_models import Matcher
 from src.service.kb_auth import KBaseAuth
-from src.service.storage_arango import ArangoStorage, ARANGO_ERR_NAME_EXISTS
-from src.service.timestamp import now_epoch_millis
 
 # The main point of this module is to handle all the application state in one place
 # to keep it consistent and allow for refactoring without breaking other code
-
-
-class PickleableDependencies:
-    """
-    Enables getting a system dependencies in a separate process via pickling the information needed
-    to recreate said dependencies.
-    """
-
-    def __init__(
-        self,
-        cfg: CollectionsServiceConfig,
-        data_products: dict[str, list[DBCollection]]
-    ):
-        self._cfg = cfg
-        self._dps = data_products
-    
-    async def get_storage(self) -> tuple[aioarango.ArangoClient, ArangoStorage]:
-        """
-        Get the Arango client and storage system. The arango client must be closed when the
-        storage system is no longer necessary.
-        """
-        return await _build_storage(self._cfg, self._dps)
-
-    async def get_workspace(self, token):
-        """
-        Get the workspace client.
-
-        token - the user's token.
-        """
-        return Workspace(cfg.workspace_url, token=token)
-    
-    def get_epoch_ms(self) -> int:
-        """
-        Get the Unix epoch time in milliseconds.
-        """
-        # This allows for easy mocking of time generation rather than having to monkey patch
-        # time.time
-        return now_epoch_millis()
-
-
-class CollectionsState:
-    """
-    State information about the collections system. Contains means to access DB storage,
-    external systems, etc.
-
-    Instance variables:
-
-    auth - a KBaseAuth client.
-    arangostorage - an ArangoStorage wrapper.
-    """
-
-    def __init__(
-        self,
-        auth: KBaseAuth,
-        arangoclient: aioarango.ArangoClient,
-        arangostorage: ArangoStorage,
-        data_products: dict[str, list[DBCollection]],
-        matchers: list[Matcher],
-        cfg: CollectionsServiceConfig,
-    ):
-        """
-        Do not instantiate this class directly. Use `build_app` to create the app state and
-        `get_app_state` or `get_app_state_from_app` to access it.
-        """
-        self.auth = auth
-        self._client = arangoclient
-        self.arangostorage = arangostorage
-        self._data_products = data_products
-        self._matchers = {m.id: m for m in matchers}
-        self._cfg = cfg
-
-    async def destroy(self):
-        """
-        Destroy any resources held by this class. After this the class should be discarded.
-        """
-        await self._client.close()
-
-    def get_workspace_client(self, token) -> Workspace:
-        """
-        Get a client for the KBase Workspace.
-
-        token - the user's token.
-        """
-        return Workspace(self._cfg.workspace_url, token=token)
-
-    def get_pickleable_dependencies(self) -> PickleableDependencies:
-        """
-        Get an object that can be pickled, passed to another process, and used to reinitialize the
-        system dependencies there.
-        """
-        return PickleableDependencies(self._cfg, self._data_products)
-
-    def get_matcher(self, matcher_id) -> Matcher | None:
-        """
-        Get a matcher by its ID. Returns None if no such matcher exists.
-        """
-        return self._matchers.get(matcher_id)
-
-    def get_matchers(self) -> list[Matcher]:
-        """
-        Get all the matchers registered in the system.
-        """
-        return list(self._matchers.values())
-
-    def get_epoch_ms(self) -> int:
-        """
-        Get the Unix epoch time in milliseconds.
-        """
-        # This allows for easy mocking of time generation rather than having to monkey patch
-        # time.time
-        return now_epoch_millis()
 
 
 async def build_app(
@@ -153,7 +38,7 @@ async def build_app(
     data_products = {dp.data_product: dp.db_collections for dp in data_products}
     await _check_workspace_url(cfg)
     # do this last in case the steps above throw an exception. cli needs to be closed
-    cli, storage = await _build_storage(cfg, data_products)
+    cli, storage = await build_storage(cfg, data_products)
     app.state._colstate = CollectionsState(auth, cli, storage, data_products, matchers, cfg)
 
 
@@ -173,31 +58,6 @@ def get_app_state_from_app(app: FastAPI) -> CollectionsState:
     return app.state._colstate
 
 
-async def _build_storage(
-    cfg: CollectionsServiceConfig,
-    data_products: dict[str, list[DBCollection]],
-) -> tuple[aioarango.ArangoClient, ArangoStorage]:
-    cli = aioarango.ArangoClient(hosts=cfg.arango_url)
-    try:
-        if cfg.create_db_on_startup:
-            sysdb = await _get_arango_db(cli, "_system", cfg)
-            try:
-                await sysdb.create_database(cfg.arango_db)
-            except aioarango.exceptions.DatabaseCreateError as e:
-                if e.error_code != ARANGO_ERR_NAME_EXISTS:  # ignore, db exists
-                    raise
-        db = await _get_arango_db(cli, cfg.arango_db, cfg)
-        storage = await ArangoStorage.create(
-            db,
-            data_products=data_products,
-            create_collections_on_startup=cfg.create_db_on_startup
-        )
-        return cli, storage
-    except:
-        await cli.close()
-        raise
-
-
 async def _check_workspace_url(cfg: CollectionsServiceConfig) -> str:
     try:
         ws = Workspace(cfg.workspace_url)
@@ -205,28 +65,3 @@ async def _check_workspace_url(cfg: CollectionsServiceConfig) -> str:
         print("Workspace version: " + ws.ver())
     except Exception as e:
         raise ValueError(f"Could not connect to workspace at {cfg.workspace_url}: {str(e)}") from e
-
-
-async def _get_arango_db(cli: aioarango.ArangoClient, db: str, cfg: CollectionsServiceConfig
-) -> aioarango.database.StandardDatabase:
-    err = None
-    for t in [1, 2, 5, 10, 30]:
-        try:
-            if cfg.arango_user:
-                rdb = await cli.db(
-                    db, verify=True, username=cfg.arango_user, password=cfg.arango_pwd)
-            else:
-                rdb = await cli.db(db, verify=True)
-            return rdb
-        except aioarango.exceptions.ServerConnectionError as e:
-            err = e
-            print(  f"Failed to connect to Arango database at {cfg.arango_url}\n"
-                  + f"    Error: {err}\n"
-                  + f"    Waiting for {t}s and retrying db connection"
-            )
-            sys.stdout.flush()
-            # TODO CODE both time.sleep() and this block SIGINT. How to fix?
-            await asyncio.sleep(t)
-    raise ValueError(f"Could not connect to Arango at {cfg.arango_url}") from err
-
-

--- a/src/service/app_state_data_structures.py
+++ b/src/service/app_state_data_structures.py
@@ -1,0 +1,125 @@
+"""
+Data structures to store app state.
+"""
+
+import aioarango
+
+from src.service._app_state_build_storage import build_storage
+from src.service.config import CollectionsServiceConfig
+from src.service.clients.workspace_client import Workspace
+from src.service.data_products.common_models import DBCollection
+from src.service.kb_auth import KBaseAuth
+from src.service.matchers.common_models import Matcher
+from src.service.storage_arango import ArangoStorage
+from src.service.timestamp import now_epoch_millis
+
+
+class PickleableDependencies:
+    """
+    Enables getting a system dependencies in a separate process via pickling the information needed
+    to recreate said dependencies.
+    """
+
+    def __init__(
+        self,
+        cfg: CollectionsServiceConfig,
+        data_products: dict[str, list[DBCollection]]
+    ):
+        self._cfg = cfg
+        self._dps = data_products
+    
+    async def get_storage(self) -> tuple[aioarango.ArangoClient, ArangoStorage]:
+        """
+        Get the Arango client and storage system. The arango client must be closed when the
+        storage system is no longer necessary.
+        """
+        return await build_storage(self._cfg, self._dps)
+
+    async def get_workspace(self, token):
+        """
+        Get the workspace client.
+
+        token - the user's token.
+        """
+        return Workspace(cfg.workspace_url, token=token)
+    
+    def get_epoch_ms(self) -> int:
+        """
+        Get the Unix epoch time in milliseconds.
+        """
+        # This allows for easy mocking of time generation rather than having to monkey patch
+        # time.time
+        return now_epoch_millis()
+
+
+class CollectionsState:
+    """
+    State information about the collections system. Contains means to access DB storage,
+    external systems, etc.
+
+    Instance variables:
+
+    auth - a KBaseAuth client.
+    arangostorage - an ArangoStorage wrapper.
+    """
+
+    def __init__(
+        self,
+        auth: KBaseAuth,
+        arangoclient: aioarango.ArangoClient,
+        arangostorage: ArangoStorage,
+        data_products: dict[str, list[DBCollection]],
+        matchers: list[Matcher],
+        cfg: CollectionsServiceConfig,
+    ):
+        """
+        Do not instantiate this class directly. Use `app_state.build_app` to create the app state
+        and `app_state.get_app_state` or `app_state.get_app_state_from_app` to access it.
+        """
+        self.auth = auth
+        self._client = arangoclient
+        self.arangostorage = arangostorage
+        self._data_products = data_products
+        self._matchers = {m.id: m for m in matchers}
+        self._cfg = cfg
+
+    async def destroy(self):
+        """
+        Destroy any resources held by this class. After this the class should be discarded.
+        """
+        await self._client.close()
+
+    def get_workspace_client(self, token) -> Workspace:
+        """
+        Get a client for the KBase Workspace.
+
+        token - the user's token.
+        """
+        return Workspace(self._cfg.workspace_url, token=token)
+
+    def get_pickleable_dependencies(self) -> PickleableDependencies:
+        """
+        Get an object that can be pickled, passed to another process, and used to reinitialize the
+        system dependencies there.
+        """
+        return PickleableDependencies(self._cfg, self._data_products)
+
+    def get_matcher(self, matcher_id) -> Matcher | None:
+        """
+        Get a matcher by its ID. Returns None if no such matcher exists.
+        """
+        return self._matchers.get(matcher_id)
+
+    def get_matchers(self) -> list[Matcher]:
+        """
+        Get all the matchers registered in the system.
+        """
+        return list(self._matchers.values())
+
+    def get_epoch_ms(self) -> int:
+        """
+        Get the Unix epoch time in milliseconds.
+        """
+        # This allows for easy mocking of time generation rather than having to monkey patch
+        # time.time
+        return now_epoch_millis()

--- a/src/service/data_product_specs.py
+++ b/src/service/data_product_specs.py
@@ -2,7 +2,7 @@
 Defines active data products in the service.
 
 To add a data product to the service, create a new module in the data_products directory
-and define a DataProductSpec. Import it in this file and add it to the DATA_PRODUCTS variable.
+and define a DataProductSpec. Add the import path and DPS variable name to the _SPECS variable.
 The data product routes will be added to the OpenAPI UI in the same order as the first
 item in the `tags` field of the router.
 
@@ -12,13 +12,47 @@ Note that "builtin" is a reserved ID for data products.
 # NOTE: Once a collection has been saved with a data product, the data product cannot be
 # removed from the service without breaking that collection.
 
+import importlib
+
 from src.service.data_products.common_models import DataProductSpec
-from src.service.data_products.taxa_count import TAXA_COUNT_SPEC
-from src.service.data_products.genome_attributes import GENOME_ATTRIBS_SPEC
 
-
-DATA_PRODUCTS: dict[str, DataProductSpec] = {
-    TAXA_COUNT_SPEC.data_product: TAXA_COUNT_SPEC,
-    GENOME_ATTRIBS_SPEC.data_product: GENOME_ATTRIBS_SPEC,
+_SPECS = {
+    "src.service.data_products.taxa_count": "TAXA_COUNT_SPEC",
+    "src.service.data_products.genome_attributes": "GENOME_ATTRIBS_SPEC",
 }
-""" Set of data products the service supports. """
+
+_IMPORT_CACHE = {}  # load at app startup to prevent import loops
+
+
+def _ensure_cache():
+    if not _IMPORT_CACHE:
+        for mod, spec in _SPECS.items():
+            # just throw the errors for now, maybe do a bit better error handling if needed later
+            loaded = getattr(importlib.import_module(mod), spec)
+            _IMPORT_CACHE[loaded.data_product] = loaded
+
+
+def get_data_product_spec(data_product: str) -> DataProductSpec:
+    """
+    Get a spec for a data product.
+    """
+    _ensure_cache()
+    if data_product not in _IMPORT_CACHE:
+        raise ValueError(f"No such data product: {data_product}")
+    return _IMPORT_CACHE[data_product]
+
+
+def get_data_product_names() -> list[str]:
+    """
+    Get the sorted list of names of installed data products.
+    """
+    _ensure_cache()
+    return sorted(_IMPORT_CACHE.keys())
+
+
+def get_data_products() -> list[DataProductSpec]:
+    """
+    Get the list of installed data products in no particular order.
+    """
+    _ensure_cache()
+    return list(_IMPORT_CACHE.values())

--- a/src/service/data_products/taxa_count.py
+++ b/src/service/data_products/taxa_count.py
@@ -10,6 +10,7 @@ from src.common.gtdb_lineage import GTDBTaxaCount
 from src.common.storage.db_doc_conversions import taxa_node_count_to_doc
 import src.common.storage.collection_and_field_names as names
 from src.service import app_state
+from src.service.app_state_data_structures import PickleableDependencies, CollectionsState
 from src.service import errors
 from src.service import kb_auth
 from src.service import match_retrieval
@@ -246,7 +247,7 @@ async def get_taxa_counts(
 
 
 async def _get_data_product_match(
-    appstate: app_state.CollectionsState,
+    appstate: CollectionsState,
     collection_id: str,
     match_id: str,
     user: kb_auth.KBaseUser
@@ -314,7 +315,7 @@ async def _query(
     return ret
 
 
-async def _process_match(match_id: str, deps: app_state.PickleableDependencies, args: list):
+async def _process_match(match_id: str, deps: PickleableDependencies, args: list):
     # TODO DOCS document that match processes should run the process regardless of the state
     #      of the match. It is up to the code starting the process to ensure it is correct to
     #      start the match process. As such, the match processes should be idempotent.

--- a/src/service/match_retrieval.py
+++ b/src/service/match_retrieval.py
@@ -6,7 +6,7 @@ to the match, the match is in the expected state, and access times are updated c
 import logging
 from typing import Any, Callable
 
-from src.service import app_state
+from src.service.app_state_data_structures import PickleableDependencies, CollectionsState
 # kinda feel like users should be more generic, but not work the trouble
 from src.service import kb_auth
 from src.service import errors
@@ -22,7 +22,7 @@ _PERM_RECHECK_LIMIT = 5 * 60 * 1000  # check perms every 5 mins
 
 
 async def get_match(
-    deps: app_state.CollectionsState,
+    deps: CollectionsState,
     match_id: str,
     user: kb_auth.KBaseUser,
     verbose: bool = False,
@@ -56,7 +56,7 @@ async def get_match(
 
 
 async def get_match_full(
-    deps: app_state.CollectionsState,
+    deps: CollectionsState,
     match_id: str,
     user: kb_auth.KBaseUser,
     verbose: bool = False,
@@ -78,7 +78,7 @@ async def get_match_full(
 
 async def _get_match(
     internal: bool,
-    deps: app_state.CollectionsState,
+    deps: CollectionsState,
     match_id: str,
     user: kb_auth.KBaseUser,
     verbose: bool,
@@ -118,7 +118,7 @@ async def _check_match_state(
     match: models.MatchVerbose,
     require_complete: bool,
     require_collection: models.SavedCollection,
-    deps: app_state.CollectionsState,
+    deps: CollectionsState,
     ww: WorkspaceWrapper,
 ) -> None:
     col = require_collection
@@ -144,7 +144,7 @@ async def _check_match_state(
 
 
 def _requires_restart(
-    deps: app_state.CollectionsState,
+    deps: CollectionsState,
     match: models.InternalMatch | models.DataProductMatchProcess,
     match_state: models.MatchState,
 ) -> bool:
@@ -200,10 +200,10 @@ async def create_match_process(
 
 
 async def get_or_create_data_product_match(
-    deps: app_state.CollectionsState,
+    deps: CollectionsState,
     match: models.InternalMatch,
     data_product: str,
-    match_process: Callable[[str, app_state.PickleableDependencies, list[Any]], None],
+    match_process: Callable[[str, PickleableDependencies, list[Any]], None],
 ) -> models.DataProductMatchProcess:
     """
     Get a match process data structure for a data product match.
@@ -244,7 +244,7 @@ async def get_or_create_data_product_match(
 
 def _start_process(
     match_id: str,
-    match_process: Callable[[str, app_state.PickleableDependencies, list[Any]], None],
-    deps: app_state.PickleableDependencies,
+    match_process: Callable[[str, PickleableDependencies, list[Any]], None],
+    deps: PickleableDependencies,
 ) -> None:
     processing.CollectionProcess(process=match_process, args=[]).start(match_id, deps)

--- a/src/service/matchers/lineage_matcher.py
+++ b/src/service/matchers/lineage_matcher.py
@@ -10,7 +10,7 @@ from typing import Any, Callable
 from src.common.storage.collection_and_field_names import FLD_GENOME_ATTRIBS_GTDB_LINEAGE
 from src.service import errors
 from src.service import models
-from src.service.app_state import PickleableDependencies
+from src.service.app_state_data_structures import PickleableDependencies
 from src.service.processing import CollectionProcess, Heartbeat, HEARTBEAT_INTERVAL_SEC
 from src.service.data_products import genome_attributes
 from src.service.matchers.common_models import Matcher

--- a/src/service/processing.py
+++ b/src/service/processing.py
@@ -10,7 +10,7 @@ import multiprocessing
 
 from pydantic import BaseModel, Field
 from typing import Callable, Any
-from src.service.app_state import PickleableDependencies
+from src.service.app_state_data_structures import PickleableDependencies
 from src.service.timestamp import now_epoch_millis
 
 

--- a/src/service/routes_collections.py
+++ b/src/service/routes_collections.py
@@ -59,8 +59,7 @@ def _check_matchers_and_data_products(
 ):
     data_products = set([dp.product for dp in col.data_products])
     for dp in data_products:
-        if dp not in data_product_specs.DATA_PRODUCTS:
-            raise errors.NoSuchDataProduct(f"No such data product: {dp}")
+        data_product_specs.get_data_product_spec(dp)  # throws an exception if missing
     for m in col.matchers:
         matcher = appstate.get_matcher(m.matcher)
         if not matcher:


### PR DESCRIPTION
* Made the data product registry load data products on request rather than at import time to break import cycles. Now we can reference the data product registry in various places without import loops.
* Split up app_state to allow importing subparts of the state and avoiding import loops.