### PR TITLE
add global task info file

### DIFF
--- a/src/loaders/jobs/taskfarmer/task_generator.py
+++ b/src/loaders/jobs/taskfarmer/task_generator.py
@@ -297,8 +297,6 @@ def _append_task_info(root_dir, task_info):
 
     # Append the new record to the file
     with jsonlines.open(task_info_file, mode='a') as writer:
-        if not os.path.exists(task_info_file):
-            writer.write([])
         writer.write(task_info)
 
 
@@ -366,7 +364,8 @@ def main():
 
     if job_id:
         task_info = {'kbase_collection': kbase_collection, 'load_ver': load_ver, 'tool': tool,
-                     'job_id': job_id, 'job_start_time': current_datetime.strftime("%Y-%m-%d %H:%M:%S")}
+                     'job_id': job_id, 'job_start_time': current_datetime.strftime("%Y-%m-%d %H:%M:%S"),
+                     'source_data_dir': source_data_dir}
         _append_task_info(root_dir, task_info)
 
 

--- a/src/loaders/jobs/taskfarmer/task_generator.py
+++ b/src/loaders/jobs/taskfarmer/task_generator.py
@@ -17,7 +17,7 @@ usage: task_generator.py [-h] --tool {gtdb_tk} --kbase_collection
                          KBASE_COLLECTION --load_ver LOAD_VER
                          --source_data_dir SOURCE_DATA_DIR
                          [--root_dir ROOT_DIR] [--image_tag IMAGE_TAG]
-                         [--use_cached_image] [--submit_job]
+                         [--use_cached_image] [--submit_job] [--force]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -37,6 +37,7 @@ optional arguments:
                         Docker/Shifter image tag. (default: latest)
   --use_cached_image    Use an existing image without pulling
   --submit_job          Submit job to slurm
+  --force               Force overwrite of existing job directory
 '''
 
 TOOLS_AVAILABLE = ['gtdb_tk']  # TODO: fix checkm2 container bug


### PR DESCRIPTION
add global task info file so that we can look up job ids attached to each task. NERSC only caches job status for a certain period of time.