### PR TITLE
Fix lineage parsing

### DIFF
--- a/src/common/gtdb_lineage.py
+++ b/src/common/gtdb_lineage.py
@@ -11,6 +11,14 @@ class GTDBLineageRankError(Exception):
     """Raised when a GTDB lineage has incorrect ranks."""
 
 
+class GTDBLineageParseError(Exception):
+    """Raised when a GTDB lineage string cannot be parsed."""
+
+
+class GTDBLineageResolutionError(Exception):
+    """Raised with a GTDB lineage is not fully resolved."""
+
+
 class GTDBRank(str, enum.Enum):
     """
     Ranks in the GTDB lineage system.
@@ -96,6 +104,10 @@ class GTDBLineageNode:
     def __str__(self):
         return f"{self.rank.abbrev}__{self.name}"
 
+    def __repr__(self):
+        # doesn't really work as a repr but good enough for debugging. Fix if needed.
+        return f"{self.__class__.__name__}({repr(self.rank)}, {self.name})"
+
     def __eq__(self, other):
         return (self.rank, self.name) == (other.rank, other.name)
 
@@ -111,57 +123,71 @@ class GTDBLineage:
 
     lineage: tuple[GTDBLineageNode]
 
-    def __init__(self, lineage: list[GTDBLineageNode]):
+    def __init__(self, linstr: str, force_complete=False):
         """
-        Create the lineage.
-        """
-        if not lineage:
-            raise ValueError("lineage required")
-        ranks = [r for r in GTDBRank][:len(lineage)]
-        for n, r in zip(lineage, ranks):
-            if n.rank != r:
-                raise GTDBLineageOrderError(
-                    f"Bad rank order in lineage {self._to_str(lineage)}")
-        self.lineage = tuple(lineage)
+        Create the lineage from a gdtb lineage string, omitting unresolved ranks.
 
-    def _to_str(self, lineage: Iterable[GTDBLineageNode]) -> str:
-        return ";".join([str(n) for n in lineage])
+        linstr - the lineage string
+        force_complete - throw a GTDBResolutionError if the lineage string is not fully resolved.
+        """
+        # This may probably not handle incorrectly formatted lineage strings well - haven't thought
+        # through all possible cases. For now all our inputs are expected to be coming from GTDB
+        # or GTDB_tk so we'll worry about that later.
+        ret = []
+        resolved = True
+        linparts = linstr.strip().split(";")
+        linparts = linparts if linparts[-1].strip() else linparts[:-1]  # remove trailing ;
+        for lin in linparts:
+            node = lin.split("__")
+            if len(node) != 2:
+                raise GTDBLineageParseError(f"Invalid lineage node '{lin}' in lineage '{linstr}'")
+            taxa_abbrev, taxa_name = [n.strip() for n in node]
+            if not taxa_name:
+                resolved = False
+            elif not resolved:
+                raise GTDBLineageParseError(
+                    f"Found resolved rank after unresolved rank in lineage string '{linstr}'")
+            else:
+                try:
+                    ret.append(
+                        GTDBLineageNode(GTDBRank.from_abbreviation(taxa_abbrev), taxa_name))
+                except ValueError as e:  # maybe want a more specific error?
+                    raise GTDBLineageParseError(
+                        f"Illegal rank in lineage string '{linstr}': {str(e)}")
+        if not ret:
+            raise GTDBLineageResolutionError(
+                f"No lineage information in lineage string '{linstr}'")
+        if force_complete and ret[-1].rank != GTDBRank.SPECIES:
+            raise GTDBLineageResolutionError(f"Lineage '{linstr}' does not end with species")
+        ranks = [r for r in GTDBRank][:len(ret)]
+        for n, r in zip(ret, ranks):
+            if n.rank != r:
+                raise GTDBLineageRankError(
+                    f"Bad rank order in lineage '{linstr}'")
+        self.lineage = tuple(ret)
 
     def __str__(self):
-        return self._to_str(self.lineage)
+        return ";".join([str(n) for n in self.lineage])
 
     def __eq__(self, other):
         return self.lineage == other.lineage
 
-    def truncate_to_rank(self, rank: GTDBRank) -> Self:
+    def truncate_to_rank(self, rank: GTDBRank) -> Self | None:
         """
         Truncate this lineage up to and including the given rank. If the rank does not occur in
         the lineage, None is returned.
         """
         try:
             idx = [n.rank for n in self.lineage].index(rank)
-            return type(self)(self.lineage[:idx + 1])
+            # this is gross and hacky. Need constructor polymorphism to do this sanely
+            lin = type(self)("d__domain", force_complete=False)
+            lin.lineage = self.lineage[:idx + 1]
+            return lin
         except ValueError:
             return None
 
 
 TaxaNodeCount = namedtuple("TaxaNodeCount", "rank name count")
-
-
-def parse_gtdb_lineage_string(linstr: str, force_complete=True) -> GTDBLineage:
-    """
-    Parse a gdtb lineage string into its component parts.
-    """
-    # This will probably not handle incorrectly formatted lineage strings well. For now all our
-    # inputs are expected to be coming from GTDB or GTDB_tk so we'll worry about that later.
-    ln = linstr.split(";")
-    ret = []
-    for lin in ln:
-        taxa_abbrev, taxa_name = lin.split("__")
-        ret.append(GTDBLineageNode(GTDBRank.from_abbreviation(taxa_abbrev), taxa_name))
-    if force_complete and ret[-1].rank != GTDBRank.SPECIES:
-        raise ValueError(f"Lineage {linstr} does not end with species")
-    return GTDBLineage(ret)
 
 
 class GTDBTaxaCount:
@@ -179,7 +205,7 @@ class GTDBTaxaCount:
         """
         Process a GTDB lineage string and add it to the taxa count information.
         """
-        lineage = parse_gtdb_lineage_string(gtdb_lineage_string)
+        lineage = GTDBLineage(gtdb_lineage_string)
         for lin in lineage.lineage:
             self._counts[lin.rank][lin.name] += 1
 

--- a/src/service/data_products/genome_attributes.py
+++ b/src/service/data_products/genome_attributes.py
@@ -4,7 +4,7 @@ The genome_attribs data product, which provides geneome attributes for a collect
 
 from fastapi import APIRouter, Request, Depends, Query
 from pydantic import BaseModel, Field, Extra
-from src.common.gtdb_lineage import parse_gtdb_lineage_string, GTDBRank
+from src.common.gtdb_lineage import GTDBLineage, GTDBRank
 import src.common.storage.collection_and_field_names as names
 from src.service import app_state
 from src.service import errors
@@ -352,7 +352,9 @@ async def perform_gtdb_lineage_match(
     load_ver = {dp.product: dp.version for dp in coll.data_products}[ID]
     filtered_lineages = set()  # remove duplicates
     for lin in lineages:
-        lineage = parse_gtdb_lineage_string(lin, force_complete=False).truncate_to_rank(rank)
+        # may need to catch errors here and report with object UPA or something
+        # or parse lineages prior to starting the process, that's probably better
+        lineage = GTDBLineage(lin, force_complete=False).truncate_to_rank(rank)
         if lineage:
             filtered_lineages.add(str(lineage))
     if rank == GTDBRank.SPECIES:


### PR DESCRIPTION
GTDB_tk always outputs full ranks; a missing name indicates an unresolved rank.

Also move the parsing logic to the class constructor.