### PR TITLE
RE2022-115: Add selection manipulation methods to the DB layer

### DIFF
--- a/src/common/storage/collection_and_field_names.py
+++ b/src/common/storage/collection_and_field_names.py
@@ -61,6 +61,12 @@ COLL_SRV_MATCHES_DELETED = COLL_SRV_MATCHES + "_deleted"
 COLL_SRV_MATCHES_DATA_PRODUCTS = COLL_SRV_MATCHES + "_data_prods"
 """ A collection holding the status of calculating secondary data products for matches. """
 
+COLL_SRV_ACTIVE_SELECTIONS = _SRV_PREFIX + "selections_active"
+""" A collection holding active selections. """
+
+COLL_SRV_INTERNAL_SELECTIONS = _SRV_PREFIX + "selections_internal"
+""" A collection holding the internal state of selections. """
+
 ## Data product collections
 
 ### Taxa counts

--- a/src/service/errors.py
+++ b/src/service/errors.py
@@ -76,6 +76,9 @@ class ErrorType(Enum):
     NO_SUCH_MATCH =              (40030, "No such match")  # noqa: E222 @IgnorePep8
     """ The requested match does not exist. """
 
+    NO_SUCH_SELECTION =          (40040, "No such selection")  # noqa: E222 @IgnorePep8
+    """ The requested selection does not exist. """
+
     COLLECTION_VERSION_EXISTS =  (50000, "Collection version exists")  # noqa: E222 @IgnorePep8
     """ The requested collection version already exists. """
 
@@ -282,6 +285,15 @@ class NoSuchMatchError(NoDataException):
 
     def __init__(self, message: str):
         super().__init__(ErrorType.NO_SUCH_MATCH, message)
+
+
+class NoSuchSelectionError(NoDataException):
+    """
+    An error thrown when a selection does not exist.
+    """
+
+    def __init__(self, message: str):
+        super().__init__(ErrorType.NO_SUCH_SELECTION, message)
 
 
 class DataPermissionError(CollectionError):

--- a/src/service/models.py
+++ b/src/service/models.py
@@ -41,7 +41,7 @@ FIELD_DATA_PRODUCTS = "data_products"
 FIELD_DATA_PRODUCTS_PRODUCT = "product"
 FIELD_MATCHERS = "matchers"
 FIELD_MATCHERS_MATCHER = "matcher"
-FIELD_MATCH_LAST_ACCESS = "last_access"
+FIELD_LAST_ACCESS = "last_access"  # applies to both selections and matches
 FIELD_MATCH_INTERNAL_MATCH_ID = "internal_match_id"
 FIELD_MATCH_HEARTBEAT = "heartbeat"
 FIELD_MATCH_USER_PERMS = "user_last_perm_check"
@@ -50,6 +50,7 @@ FIELD_MATCH_STATE_UPDATED = "match_state_updated"
 FIELD_DATA_PRODUCT_MATCH_STATE = "data_product_match_state"
 FIELD_DATA_PRODUCT_MATCH_STATE_UPDATED = "data_product_match_state_updated"
 FIELD_MATCH_MATCHES = "matches"
+FIELD_SELECTION_STATE = "selection_state"
 FIELD_DATE_CREATE = "date_create"
 FIELD_USER_CREATE = "user_create"
 FIELD_DATE_ACTIVE = "date_active"
@@ -437,8 +438,14 @@ class ActiveSelection(BaseModel):
     since selections do not require auth, is effectively a session token) to an internal
     selection ID.
     """
-    external_selection_id: str = Field(
-        description="The external ID of the selection, presumably a session token."
+    selection_id_hash: str = Field(
+        description="The external ID of the selection, presumably a session token, hashed for "
+            + "database storage."
+    )
+    active_selection_id: str = Field(
+        example="e22f2d7d-7246-4636-a91b-13f29bc32d3d",
+        description="An ID used to refer to this active selection that is loggable, as it is "
+            + "not a session token and not visisble outside the service."
     )
     internal_selection_id: str = Field(
         example="e22f2d7d-7246-4636-a91b-13f29bc32d3d",


### PR DESCRIPTION
```python
In [1]: from src.service.storage_arango import ArangoStorage
f
In [2]: from src.service import data_product_specs

In [4]: from src.service import models

In [5]: import aioarango

In [6]: cli = aioarango.ArangoClient(hosts='http://localhost:8529')

In [7]: db = await cli.db("collections_test", username="root", password="foobar"
   ...: )

In [8]: dps = {dp.data_product: dp.db_collections for dp in data_product_specs.g
   ...: et_data_products()}

In [9]: arst = await ArangoStorage.create(db, dps)

In [10]: sa = models.ActiveSelection(
    ...:     selection_id_hash="super_secure",
    ...:     active_selection_id="some_id",
    ...:     internal_selection_id="foo",
    ...:     last_access=42
    ...:     )

In [11]: await arst.save_selection_active(sa)

In [12]: await arst.get_selection_active("super_secure")
Out[12]: ActiveSelection(selection_id_hash='super_secure', active_selection_id='some_id', internal_selection_id='foo', last_access=42)

In [13]: await arst.get_selection_active("super_securex")
---------------------------------------------------------------------------
NoSuchSelectionError                      Traceback (most recent call last)
Cell In[13], line 1
*snip*
NoSuchSelectionError: There is no selection by the given selection ID.

In [14]: await arst.update_selection_active_last_acess("super_secure", 96)

In [15]: await arst.get_selection_active("super_secure")
Out[15]: ActiveSelection(selection_id_hash='super_secure', active_selection_id='some_id', internal_selection_id='foo', last_access=96)

In [16]: si = models.InternalSelection(
    ...:     internal_selection_id="foo",
    ...:     collection_id="GTDB",
    ...:     collection_ver=8,
    ...:     selection_ids=["1", "2"],
    ...:     created=42,
    ...:     heartbeat=None,
    ...:     selection_state=models.ProcessState.PROCESSING,
    ...:     selection_state_updated=78
    ...:     )

In [19]: await arst.save_selection_internal(si)

In [20]: await arst.get_selection_internal("foo")
Out[20]: InternalSelection(internal_selection_id='foo', collection_id='GTDB', collection_ver=8, selection_ids=['1', '2'], created=42, heartbeat=None, selection_state=<ProcessState.PROCESSING: 'processing'>, selection_state_updated=78)

In [21]: await arst.get_selection_internal("foox")
---------------------------------------------------------------------------
NoSuchSelectionError                      Traceback (most recent call last)
Cell In[21], line 1
*snip*
NoSuchSelectionError: There is no internal selection foox
```