### PR TITLE
Send process heartbeat immediately

### DIFF
--- a/src/service/processing.py
+++ b/src/service/processing.py
@@ -5,7 +5,6 @@ both performing the initial match and calculating secondary data products.
 
 import asyncio
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from apscheduler.triggers.interval import IntervalTrigger
 import logging
 import multiprocessing
 
@@ -113,10 +112,8 @@ class Heartbeat:
         """
         if self._job_id:
             raise ValueError("Heartbeat is already running")
-        job = self._schd.add_job(
-            func=self._heartbeat,
-            trigger=IntervalTrigger(seconds=self._interval_sec)
-        )
+        self._schd.add_job(self._heartbeat)  # run immediately
+        job = self._schd.add_job(self._heartbeat, "interval", seconds=self._interval_sec)
         self._job_id = job.id
         self._schd.start()
 


### PR DESCRIPTION
This reduces the period when multiple processes can be started for short jobs that never send a heartbeat after the creation time is > 60s in the past.

To reduce further, could add a process started field that the main process updates when it starts the process and take that into account in the restart calculation. This change should fix most of the problem, though, so don't worry about that for now.