### PR TITLE
RE2022-137 Get type info for a data product

### DIFF
--- a/src/common/storage/collection_and_field_names.py
+++ b/src/common/storage/collection_and_field_names.py
@@ -23,11 +23,14 @@ FLD_COLLECTION_ID = "coll"
 FLD_LOAD_VERSION = "load_ver"
 """ The name of the key that has a load version as its value. """
 
-FLD_MATCH_ID = "match_id"
-""" The name of the key that has a match ID as its value. """
+FLD_DATA_PRODUCT = "data_product"
+""" The name of the key that has a data product ID as its value. """
 
 FLD_INTERNAL_ID = "internal_id"
 """ The name of the key that has an internal match ID as its value. """
+
+FLD_TYPES = "types"
+""" The name of the key that has a list of workspace types as its value. """
 
 # Collections
 
@@ -66,6 +69,11 @@ COLL_SRV_SELECTIONS = _SRV_PREFIX + "selections"
 
 COLL_SRV_SELECTIONS_DELETED = COLL_SRV_SELECTIONS + "_deleted"
 """ A collection holding selections in the deleted state. """
+
+## Non-data product specific collection shared between loaders and service
+
+# Types available for export from specific data products
+COLL_EXPORT_TYPES = COLLECTION_PREFIX + "export_types"
 
 ## Data product collections
 

--- a/src/common/storage/db_doc_conversions.py
+++ b/src/common/storage/db_doc_conversions.py
@@ -24,7 +24,7 @@ def taxa_node_count_to_doc(
     """
     full_rank = taxa_count.rank.value
     id_str = f"{internal_id}_" if internal_id else ""
-    doc = {
+    return {
         names.FLD_ARANGO_KEY: md5_string(
             f"{kbase_collection}_{load_version}_{id_str}_{full_rank}_{taxa_count.name}"
         ),
@@ -35,4 +35,25 @@ def taxa_node_count_to_doc(
         names.FLD_TAXA_COUNT_COUNT: taxa_count.count,
         names.FLD_INTERNAL_ID: internal_id,
     }
-    return doc
+
+
+def data_product_export_types_to_doc(
+    kbase_collection: str, data_product: str, load_version: str, types: list[str]
+) -> dict[str, str | list[str]]:
+    """
+    Create a document for a set of export types available for a data product.
+
+    kbase_collection - the name of the KBase collection with which the data is associated
+    data_product - the ID of the data product, e.g. `genome_attribs`
+    load_version - the load version of the data set
+    types - the list of workspace types that are exportable from the data product, e.g.
+        `KBaseGenomes.Genome`, `KBaseGenomeAnnotations.Assembly`
+    """
+    return {
+        names.FLD_ARANGO_KEY: md5_string(f"{kbase_collection}_{data_product}_{load_version}"),
+        names.FLD_COLLECTION_ID: kbase_collection,
+        names.FLD_DATA_PRODUCT: data_product,
+        names.FLD_LOAD_VERSION: load_version,
+        names.FLD_TYPES: types,
+    }
+


### PR DESCRIPTION
Also effectively defines the database structure for the type information for a data product.

```python
In [1]: from src.common.storage import collection_and_field_names as names

In [2]: from src.service.storage_arango import ArangoStorage

In [3]: from src.service import data_product_specs

In [4]: from src.common.storage.db_doc_conversions import data_product_export_ty
   ...: pes_to_doc

In [5]: import aioarango

In [6]: cli = aioarango.ArangoClient(hosts='http://localhost:8529')

In [7]: db = await cli.db("collections_test", username="root", password="foobar"
   ...: )

In [8]: dps = {dp.data_product: dp.db_collections for dp in data_product_specs.g
   ...: et_data_products()}

In [9]: arst = await ArangoStorage.create(db, dps)

In [10]: doc = data_product_export_types_to_doc("GTDB", "genome_attributes", "r2
    ...: 07.kbase.1", ["KBaseGenomeAnnotations.Assembly"])

In [11]: doc
Out[11]:
{'_key': 'd5e9cd7a14f2a7d5519519457de14f98',
 'coll': 'GTDB',
 'data_product': 'genome_attributes',
 'load_ver': 'r207.kbase.1',
 'types': ['KBaseGenomeAnnotations.Assembly']}

In [12]: await db.collection(names.COLL_EXPORT_TYPES).insert(doc)
Out[12]:
{'_id': 'kbcoll_export_types/d5e9cd7a14f2a7d5519519457de14f98',
 '_key': 'd5e9cd7a14f2a7d5519519457de14f98',
 '_rev': '_fw788RC---'}

In [13]: await arst.get_export_types("GTDB", "genome_attributes", "r207.kbase.1"
    ...: )
Out[13]: ['KBaseGenomeAnnotations.Assembly']

In [14]: await arst.get_export_types("GTDB", "genome_attributes", "r207.kbase.1x
    ...: ")
Out[14]: []
```