### PR TITLE
RE2022-143: Use internal IDs for managing match / sel processes

### DIFF
--- a/src/service/data_products/common_functions.py
+++ b/src/service/data_products/common_functions.py
@@ -301,7 +301,7 @@ async def count_simple_collection_list(
 async def mark_data_by_kbase_id(
     storage: ArangoStorage,
     collection: str,
-    subset_id: str,
+    internal_subset_id: str,
     match: bool,
     data_product:str,
     id_prefix: str = ""
@@ -320,19 +320,17 @@ async def mark_data_by_kbase_id(
 
     storage - the storage system.
     collection - the name of the arango collection to alter.
-    subset_id - the ID of the match or selection.
+    subset_id - the internal ID of the match or selection.
     match - True for a match, False for a selection.
     data_product - the data product to alter. It is assumed the data product is present in
         the collection referenced by the match or selection ID.
     id_prefix - a prefix to apply to the match or selection internal ID when marking data records.
     """
     if match:
-        colspec = await storage.get_match_full(subset_id)
-        intid = colspec.internal_match_id
+        colspec = await storage.get_match_by_internal_id(internal_subset_id)
         data_ids = colspec.matches
     else:
-        colspec = await storage.get_selection_full(subset_id)
-        intid = colspec.internal_selection_id
+        colspec = await storage.get_selection_by_internal_id(internal_subset_id)
         data_ids = colspec.selection_ids
 
     # use version number to avoid race conditions with activating collections
@@ -360,7 +358,7 @@ async def mark_data_by_kbase_id(
         "coll_id": coll.id,
         "load_ver": load_ver,
         "kbase_ids": data_ids,
-        "internal_id": id_prefix + intid,
+        "internal_id": id_prefix + internal_subset_id,
     }
     matched = set()
     # TODO TEST Should probably change this to storage.execute_aql(aql, bind_vars={}, count=False)

--- a/src/service/data_products/common_models.py
+++ b/src/service/data_products/common_models.py
@@ -4,6 +4,7 @@ Data structures common to all data products
 
 from fastapi import APIRouter, Query
 from pydantic import BaseModel, validator, Field
+from src.common.storage import collection_and_field_names as names
 from src.service import models
 from src.service import errors
 
@@ -90,4 +91,40 @@ QUERY_COUNT = Query(
     default=False,
     description="Whether to return the number of records that match the query rather than "
         + "the records themselves. Paging parameters are ignored."
+)
+
+
+QUERY_MATCH_ID = Query(
+    default = None,
+    description="A match ID to set the view to the match rather than "
+        + "the entire collection. Authentication is required. If a match ID is "
+        # matches are against a specific load version, so...
+        + "set, any load version override is ignored. "
+        + "If a selection filter and a match filter are provided, they are ANDed together. "
+        + "Has no effect on a `count` if `match_mark` is true."
+)
+
+
+QUERY_MATCH_MARK = Query(
+    default=False,
+    description="Whether to mark matched rows rather than filter based on the match ID. "
+        + "Matched rows will be indicated by a true value in the special field "
+        + f"`{names.FLD_MATCHED}`."
+)
+
+
+QUERY_SELECTION_ID = Query(
+    default=None,
+    description="A selection ID to set the view to the selection rather than the entire "
+        + "collection. If a selection ID is set, any load version override is ignored. "
+        + "If a selection filter and a match filter are provided, they are ANDed together. "
+        + "Has no effect on a `count` if `selection_mark` is true."
+)
+
+
+QUERY_SELECTION_MARK = Query(
+    default=False,
+    description="Whether to mark selected rows rather than filter based on the selection ID. "
+        + "Selected rows will be indicated by a true value in the special field "
+        + f"`{names.FLD_SELECTED}`."
 )

--- a/src/service/data_products/taxa_count.py
+++ b/src/service/data_products/taxa_count.py
@@ -150,7 +150,7 @@ class TaxaCounts(BaseModel):
     taxa_count_selection_state: models.ProcessState | None = Field(
         example=models.ProcessState.FAILED,
         description="The processing state of the selection (if any) for this data product. "
-            + "This data product requires additional processing beyond the primary match."
+            + "This data product requires additional processing beyond the primary selection."
     )
     data: list[TaxaCount] | None
 
@@ -286,7 +286,7 @@ async def _get_data_product_match(
     coll: models.SavedCollection,
     match_id: str,
     user: kb_auth.KBaseUser
-):
+) -> models.DataProductProcess:
     if not user:
         raise errors.UnauthorizedError("Authentication is required if a match ID is supplied")
     match = await processing_matches.get_match_full(
@@ -302,7 +302,7 @@ async def _get_data_product_selection(
     appstate: CollectionsState,
     coll: models.SavedCollection,
     selection_id: str,
-):
+) -> models.DataProductProcess:
     sel = await processing_selections.get_selection_full(
         appstate, selection_id, require_complete=True, require_collection=coll)
     dpid = models.DataProductProcessIdentifier(

--- a/src/service/matcher_registry.py
+++ b/src/service/matcher_registry.py
@@ -4,7 +4,9 @@ A registry of matchers available in the service.
 Matchers must inherit from the Matcher class in src.service.matchers.common_models, as well
 as implement the method:
 
-    def generate_match_process(self,
+    def generate_match_process(
+        self,
+        internal_match_id: str,
         metadata: dict[str, dict[str, Any]],
         user_parameters: dict[str, Any],
         collection_parameters: dict[str, Any],
@@ -13,6 +15,7 @@ as implement the method:
 The method checks that input metadata allows for calculating the match and throws an exception
 if that is not the case, and returns a CollectionProcess that can process the match.
 
+internal_match_id - the internal ID of the match.
 metadata - the workspace metadata of the objects to match against, mapped by its UPA.
 user_parameters - the parameters for this match supplied by the user. It it expected that the
     parameters have been validated against the matcher schema for said parameters.

--- a/src/service/processing.py
+++ b/src/service/processing.py
@@ -30,19 +30,21 @@ class CollectionProcess(BaseModel):
             + "that defines what the callable should do (typically a match or selection ID),"
             + "the storage system, and the arguments for the process as the callable arguments."
     )
+    data_id: str = Field(
+        description="The ID of data used to define what the callable should do, typically an "
+            + "internal match or selection ID."
+    )
     args: list[Any] = Field(
         description="The arguments for the process."
     )
 
-    def start(self, data_id: str, storage: PickleableDependencies):
+    def start(self, deps: PickleableDependencies):
         """
         Start the process in a forkserver.
 
-        data_id - the ID of data used to define what the callable should do, typically a match
-            or selection ID.
-        storage - the storage system containing the ID data and the data to match against.
+        deps - the system dependencies, pickleable.
         """
-        run_async_process(target=self.process, args=(data_id, storage, self.args))
+        run_async_process(target=self.process, args=(self.data_id, deps, self.args))
 
 
 def run_async_process(target: Callable, args: list[Any]):
@@ -182,4 +184,4 @@ def _start_process(
     deps: PickleableDependencies,
     args: list[Any],
 ) -> None:
-    CollectionProcess(process=process_callable, args=args).start(internal_id, deps)
+    CollectionProcess(process=process_callable, data_id=internal_id, args=args).start(deps)


### PR DESCRIPTION
Makes it easier to reuse code between primary matches / selections & secondary m/ss, since secondary m/ss only keep the internal ID in the DB record (as they should)

Also infinitesimally safer since the process will only write to the m/s they were started against and will fail if that m/s is deleted rather than writing to a new m/s (which should never happen, but...)

Also also makes the `CollectionProcess` class a little saner since the internal ID can be provided to gtdb_lineage matcher right away rather than having to wait for the matcher to calculate it and provide it to the process `start() ` method later

Finally, move the match API parameter specifications into a shared location for reuse with heatmaps