### PR TITLE
Start switch to `Annotated` param definitions

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-fastapi = "==0.95.0"
+fastapi = "==0.95.1"
 uvicorn = {version = "==0.21.1", extras = ["standard"]}
 jsonlines = "==3.1.0"
 cacheout = "==0.14.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "acc2b553bf31a96eaa3187ee8354aa7686ff7b139c7ae1c73502fa77f252340f"
+            "sha256": "ae49c97d85c9fa4889aaf586bf01d48906b2207a6deb3bda4475a95e9acfe150"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -166,11 +166,11 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
-                "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"
+                "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04",
+                "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==22.2.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==23.1.0"
         },
         "beautifulsoup4": {
             "hashes": [
@@ -356,11 +356,11 @@
         },
         "fastapi": {
             "hashes": [
-                "sha256:99d4fdb10e9dd9a24027ac1d0bd4b56702652056ca17a6c8721eec4ad2f14e18",
-                "sha256:daf73bbe844180200be7966f68e8ec9fd8be57079dff1bacb366db32729e6eb5"
+                "sha256:9569f0a381f8a457ec479d90fa01005cfddaae07546eb1f3fa035bc4797ae7d5",
+                "sha256:a870d443e5405982e1667dfe372663abf10754f246866056336d7f01c21dab07"
             ],
             "index": "pypi",
-            "version": "==0.95.0"
+            "version": "==0.95.1"
         },
         "file-read-backwards": {
             "hashes": [
@@ -1336,14 +1336,6 @@
         }
     },
     "develop": {
-        "appnope": {
-            "hashes": [
-                "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24",
-                "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"
-            ],
-            "markers": "sys_platform == 'darwin'",
-            "version": "==0.1.3"
-        },
         "asttokens": {
             "hashes": [
                 "sha256:4622110b2a6f30b77e1473affaa97e711bc2f07d3f10848420ff1898edbe94f3",
@@ -1353,11 +1345,11 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
-                "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"
+                "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04",
+                "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==22.2.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==23.1.0"
         },
         "backcall": {
             "hashes": [

--- a/src/service/data_products/common_models.py
+++ b/src/service/data_products/common_models.py
@@ -68,7 +68,6 @@ class DataProductSpec(BaseModel):
 
 
 QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE = Query(
-    default=None,
     min_length=models.LENGTH_MIN_LOAD_VERSION,
     max_length=models.LENGTH_MAX_LOAD_VERSION,
     regex=models.REGEX_LOAD_VERSION,

--- a/src/service/data_products/genome_attributes.py
+++ b/src/service/data_products/genome_attributes.py
@@ -39,7 +39,7 @@ from src.service.http_bearer import KBaseHTTPBearer
 from src.service.routes_common import PATH_VALIDATOR_COLLECTION_ID
 from src.service.storage_arango import ArangoStorage, remove_arango_keys
 from src.service.timestamp import now_epoch_millis
-from typing import Any, Callable
+from typing import Any, Callable, Annotated
 
 # Implementation note - we know FLD_KBASE_ID is unique per collection id /
 # load version combination since the loader uses those 3 fields as the arango _key
@@ -284,7 +284,7 @@ async def get_genome_attributes(
             + "Selected rows will be indicated by a true value in the special field "
             + f"`{names.FLD_GENOME_ATTRIBS_SELECTED}`."
     ),
-    load_ver_override: str | None = QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE,
+    load_ver_override: Annotated[str | None, QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE] = None,
     user: kb_auth.KBaseUser = Depends(_OPT_AUTH)
 ):
     # sorting only works here since we expect the largest collection to be ~300K records and

--- a/src/service/data_products/heatmap.py
+++ b/src/service/data_products/heatmap.py
@@ -41,6 +41,8 @@ from src.service import processing_selections
 from src.service.routes_common import PATH_VALIDATOR_COLLECTION_ID
 from src.service.storage_arango import ArangoStorage
 
+from typing import Annotated
+
 _OPT_AUTH = KBaseHTTPBearer(optional=True)
 
 _MATCH_ID_PREFIX = "m_"
@@ -184,8 +186,8 @@ class HeatMapController:
     async def get_meta_info(
         self,
         r: Request,
-        collection_id: str = PATH_VALIDATOR_COLLECTION_ID,
-        load_ver_override: str | None = QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE,
+        collection_id: Annotated[str, PATH_VALIDATOR_COLLECTION_ID],
+        load_ver_override: Annotated[str | None, QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE] = None,
         user: kb_auth.KBaseUser = Depends(_OPT_AUTH)
     ) -> heatmap_models.HeatMapMeta:
         storage = app_state.get_app_state(r).arangostorage
@@ -198,12 +200,12 @@ class HeatMapController:
     async def get_cell(
         self,
         r: Request,
-        collection_id: str = PATH_VALIDATOR_COLLECTION_ID,
+        collection_id: Annotated[str, PATH_VALIDATOR_COLLECTION_ID],
         cell_id: str = Path(
             example="4",
             description="The ID of the cell in the heatmap."
         ),
-        load_ver_override: str | None = QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE,
+        load_ver_override: Annotated[str | None, QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE] = None,
         user: kb_auth.KBaseUser = Depends(_OPT_AUTH)
     ) -> heatmap_models.CellDetail:
         storage = app_state.get_app_state(r).arangostorage
@@ -217,7 +219,7 @@ class HeatMapController:
     async def get_heatmap(
         self,
         r: Request,
-        collection_id: str = PATH_VALIDATOR_COLLECTION_ID,
+        collection_id: Annotated[str, PATH_VALIDATOR_COLLECTION_ID],
         start_after: str | None = Query(
             default=None,
             example="GB_GCA_000006155.2",
@@ -233,7 +235,7 @@ class HeatMapController:
         selection_id: str | None = QUERY_SELECTION_ID,
         selection_mark: bool = QUERY_SELECTION_MARK,
         status_only: bool = QUERY_STATUS_ONLY,
-        load_ver_override: str | None = QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE,
+        load_ver_override: Annotated[str | None, QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE] = None,
         user: kb_auth.KBaseUser = Depends(_OPT_AUTH)
     ) -> heatmap_models.HeatMap:
         appstate = app_state.get_app_state(r)

--- a/src/service/data_products/taxa_count.py
+++ b/src/service/data_products/taxa_count.py
@@ -32,7 +32,7 @@ from src.service.data_products import genome_attributes
 from src.service.http_bearer import KBaseHTTPBearer
 from src.service.routes_common import PATH_VALIDATOR_COLLECTION_ID
 from src.service.storage_arango import ArangoStorage, remove_arango_keys
-from typing import Any
+from typing import Any, Annotated
 
 
 ID = "taxa_count"
@@ -172,7 +172,7 @@ _FLD_COL_RANK = "rank"
 async def get_ranks(
     r: Request,
     collection_id: str = PATH_VALIDATOR_COLLECTION_ID,
-    load_ver_override: str | None = QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE,
+    load_ver_override: Annotated[str | None, QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE] = None,
     user: kb_auth.KBaseUser = Depends(_OPT_AUTH)
 ):
     store = app_state.get_app_state(r).arangostorage
@@ -216,7 +216,7 @@ async def get_taxa_counts(
         description="A selection ID to include the selection count in the taxa count data. "
             + "Note that if a selection ID is set, any load version override is ignored."),
     status_only: bool = QUERY_STATUS_ONLY,
-    load_ver_override: str | None = QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE,
+    load_ver_override: Annotated[str | None, QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE] = None,
     user: kb_auth.KBaseUser = Depends(_OPT_AUTH)
 ):
     appstate = app_state.get_app_state(r)


### PR DESCRIPTION
Just checking that it now works after the fastapi 0.95.1 release. From now on use the `Annotated` stycle and covert old style params over when touching them,