### PR TITLE
RE2022-148: Store missing IDs rather than fail on heatmap match / select

### DIFF
--- a/src/service/data_products/heatmap.py
+++ b/src/service/data_products/heatmap.py
@@ -295,15 +295,10 @@ class HeatMapController:
             match_or_sel.matches if dpid.is_match() else match_or_sel.selection_ids,
             (_MATCH_ID_PREFIX if dpid.is_match() else _SELECTION_ID_PREFIX) + dpid.internal_id,
         )
-        # since this is a secondary match the process shouldn't fail since the match / selection
-        # was already applied to another data product, but we should report just in case
-        state = models.ProcessState.FAILED if missed else models.ProcessState.COMPLETE
-        if missed:
-            logging.getLogger(__name__).warn(
-                f"{dpid.type.value} process with internal ID {dpid.internal_id} failed due to "
-                + f"missing data IDs: {missed}"
-            )
-        await storage.update_data_product_process_state(dpid, state, deps.get_epoch_ms())
+        # TODO NEXT add an endpoint to get the missing IDs
+        await storage.update_data_product_process_state(
+            dpid, models.ProcessState.COMPLETE, deps.get_epoch_ms(), missing_ids=missed
+        )
 
     def _heatmap(
         self,

--- a/src/service/models.py
+++ b/src/service/models.py
@@ -46,6 +46,7 @@ FIELD_MATCH_USER_PERMS = "user_last_perm_check"
 FIELD_MATCH_MATCHES = "matches"
 FIELD_SELECTION_INTERNAL_SELECTION_ID = "internal_selection_id"
 FIELD_SELECTION_UNMATCHED_IDS = "unmatched_ids"
+FIELD_DATA_PRODUCT_PROCESS_MISSING_IDS = "missing_ids"
 FIELD_DATE_CREATE = "date_create"
 FIELD_USER_CREATE = "user_create"
 FIELD_DATE_ACTIVE = "date_active"
@@ -478,6 +479,13 @@ class DataProductProcess(DataProductProcessIdentifier, ProcessAttributes):
     # last access / user perms are tracked in the primary match document. When that document
     # is deleted in the DB, this one should be as well (after deleting any data associated with
     # the match).
+    missing_ids: list[str] | None = Field(
+        example=FIELD_SELECTION_EXAMPLE,
+        description="Any IDs that were not found during the match or selection processing but "
+            + "were not in the original match. This may happen normally if a data product "
+            + "depends on data that is not available at the data source for a subset of the "
+            + "data units at the data source."
+    )
 
 
 class Selection(CollectionSpec, ProcessStateField):


### PR DESCRIPTION
It's to be expected that not all data sources will have microtrait data, or the data required to calculated it, available.

Next step is to allow the client to retrive the missing IDs.