### PR TITLE
RE2022-179: Move match / selection deletion under `admin`

### DIFF
--- a/src/service/routes_collections.py
+++ b/src/service/routes_collections.py
@@ -550,7 +550,7 @@ async def get_collection_versions(
 
 
 @ROUTER_DANGER.delete(
-    "/matchadmin/{match_id}/",
+    "/admin/matches/{match_id}/",
     response_model=models.MatchVerbose,
     summary="!!! Danger !!! Delete a match",
     description="Delete a match, regardless of state. **BE SURE YOU KNOW WHAT YOU'RE DOING**. "
@@ -571,7 +571,7 @@ async def delete_match(
 
 
 @ROUTER_DANGER.delete(
-    "/selectionadmin/{selection_id}/",
+    "/admin/selections/{selection_id}/",
     response_model=models.SelectionVerbose,
     summary="!!! Danger !!! Delete a selection",
     description="Delete a selection, regardless of state. **BE SURE YOU KNOW WHAT YOU'RE DOING**. "


### PR DESCRIPTION
Silly to have a different admin endpoint for both. Also lines up with the regular endpoint.