### PR TITLE
Move shared names to common names

### DIFF
--- a/src/common/storage/collection_and_field_names.py
+++ b/src/common/storage/collection_and_field_names.py
@@ -212,6 +212,8 @@ FLD_TAXA_COUNT_COUNT = "count"
 
 ### Genome attributes
 
+GENOME_ATTRIBS_PRODUCT_ID = "genome_attribs"
+
 COLL_GENOME_ATTRIBS: Annotated[
     str,
     COLL_ANNOTATION,
@@ -219,7 +221,7 @@ COLL_GENOME_ATTRIBS: Annotated[
         COLL_ANNOKEY_DESCRIPTION: "A collection holding genome attributes data.",
         COLL_ANNOKEY_SUGGESTED_SHARDS: 3,
     }
-] = COLLECTION_PREFIX + "genome_attribs"
+] = COLLECTION_PREFIX + GENOME_ATTRIBS_PRODUCT_ID
 
 #### Genome attribute document fields
 
@@ -277,3 +279,25 @@ COLL_MICROTRAIT_CELLS: Annotated[
         COLL_ANNOKEY_SUGGESTED_SHARDS: 3,
     }
 ] = _MICROTRAIT_COLL_PREFIX + "cells"
+
+
+### samples
+
+COLL_SAMPLES: Annotated[
+    str,
+    COLL_ANNOTATION,
+    {
+        COLL_ANNOKEY_DESCRIPTION: "A collection holding sample data.",
+        COLL_ANNOKEY_SUGGESTED_SHARDS: 3,
+    }
+    
+] = COLLECTION_PREFIX + "samples"
+
+SAMPLE_LATITUDE = "latitude"
+""" Key name for latitude data in degrees"""
+
+SAMPLE_LONGITUDE = "longitude"
+""" Key name for longitude data in degrees"""
+
+SAMPLE_GEO = '_geo_spatial'
+""" Key name for sample geo-spatial data in format of [longitude, latitude] """

--- a/src/loaders/common/loader_common_names.py
+++ b/src/loaders/common/loader_common_names.py
@@ -63,8 +63,6 @@ SOURCE_METADATA_FILE_KEYS = ["upa", "name", "type", "timestamp"]
 # callback server docker image name
 CALLBACK_IMAGE_NAME = "scanon/callback"
 
-# genome_attribs
-GENOME_ATTRIBS = "genome_attribs"
 # a list of IDs provided to the computation script
 DATA_ID_COLUMN_HEADER = "genome_id"  # TODO DATA_ID change to data ID for generality
 
@@ -110,9 +108,3 @@ SAMPLE_EFFECTIVE_TIME = "sample_effective_time"
 # extension for source sample data file and prepared sample node data file for downloaded workspace objects
 SAMPLE_FILE_EXT = "sample"
 SAMPLE_PREPARED_EXT = "prepared.sample"
-
-# key name for latitude and longitude data from sample's meta_controlled
-SAMPLE_LATITUDE = "latitude"
-SAMPLE_LONGITUDE = "longitude"
-# key name for created sample geo-spatial data in format of [longitude, latitude]
-SAMPLE_GEO = '_geo_spatial'

--- a/src/loaders/genome_collection/parse_tool_results.py
+++ b/src/loaders/genome_collection/parse_tool_results.py
@@ -508,8 +508,12 @@ def _process_genome_attri_tools(genome_attr_tools: set[str],
     _create_import_files(root_dir, output, docs)
 
     export_types_output = f'{kbase_collection}_{load_ver}_{KBCALL_EXPORT_TYPES_FILE_SUFFIX}'
-    types_doc = data_product_export_types_to_doc(kbase_collection, loader_common_names.GENOME_ATTRIBS, load_ver,
-                                                 sorted(encountered_types))
+    types_doc = data_product_export_types_to_doc(
+        kbase_collection,
+        names.GENOME_ATTRIBS_PRODUCT_ID,
+        load_ver,
+        sorted(encountered_types)
+    )
     _create_import_files(root_dir, export_types_output, [types_doc])
 
 

--- a/src/loaders/workspace_downloader/workspace_downloader.py
+++ b/src/loaders/workspace_downloader/workspace_downloader.py
@@ -58,6 +58,7 @@ from typing import Any
 
 import docker
 
+import src.common.storage.collection_and_field_names as names
 from src.clients.AssemblyUtilClient import AssemblyUtil
 from src.clients.SampleServiceClient import SampleService
 from src.clients.workspaceClient import Workspace
@@ -441,14 +442,14 @@ def _retrieve_node_data(
     sample_node = node_tree[0]
 
     meta_controlled = sample_node['meta_controlled']
-    _check_dict_contains(meta_controlled, [loader_common_names.SAMPLE_LATITUDE, loader_common_names.SAMPLE_LONGITUDE])
+    _check_dict_contains(meta_controlled, [names.SAMPLE_LATITUDE, names.SAMPLE_LONGITUDE])
     for key, meta_value in meta_controlled.items():
         _validate_node_data(key, meta_value)
         node_data[key] = meta_value['value']
 
     # create and add geo-spatial data in the format of [latitude, longitude]
-    node_data[loader_common_names.SAMPLE_GEO] = [meta_controlled[loader_common_names.SAMPLE_LATITUDE]['value'],
-                                                 meta_controlled[loader_common_names.SAMPLE_LONGITUDE]['value']]
+    node_data[names.SAMPLE_GEO] = [meta_controlled[names.SAMPLE_LATITUDE]['value'],
+                                   meta_controlled[names.SAMPLE_LONGITUDE]['value']]
 
     return node_data
 
@@ -457,7 +458,7 @@ def _validate_node_data(key, meta_value):
     # validate meta_value for a given key
 
     # validate latitude and longitude sample data
-    if key in [loader_common_names.SAMPLE_LATITUDE, loader_common_names.SAMPLE_LONGITUDE]:
+    if key in [names.SAMPLE_LATITUDE, names.SAMPLE_LONGITUDE]:
         expected_keys = ['value', 'units']
         _check_dict_keys(meta_value, expected_keys)
 

--- a/src/service/data_products/genome_attributes.py
+++ b/src/service/data_products/genome_attributes.py
@@ -1,5 +1,5 @@
 """
-The genome_attribs data product, which provides geneome attributes for a collection.
+The genome_attribs data product, which provides genome attributes for a collection.
 """
 
 from collections import defaultdict
@@ -44,7 +44,7 @@ from typing import Any, Callable, Annotated
 # Implementation note - we know FLD_KBASE_ID is unique per collection id /
 # load version combination since the loader uses those 3 fields as the arango _key
 
-ID = "genome_attribs"
+ID = names.GENOME_ATTRIBS_PRODUCT_ID
 
 _ROUTER = APIRouter(tags=["Genome Attributes"], prefix=f"/{ID}")
 


### PR DESCRIPTION
Some of the loader names are used or will need to be used in the service, so moved them to the common names file.