### PR TITLE
RE2022-203: Factor out genome attribs models for reuse

### DIFF
--- a/src/common/storage/collection_and_field_names.py
+++ b/src/common/storage/collection_and_field_names.py
@@ -293,11 +293,11 @@ COLL_SAMPLES: Annotated[
     
 ] = COLLECTION_PREFIX + "samples"
 
-SAMPLE_LATITUDE = "latitude"
+FLD_SAMPLE_LATITUDE = "latitude"
 """ Key name for latitude data in degrees"""
 
-SAMPLE_LONGITUDE = "longitude"
+FLD_SAMPLE_LONGITUDE = "longitude"
 """ Key name for longitude data in degrees"""
 
-SAMPLE_GEO = '_geo_spatial'
+FLD_SAMPLE_GEO = '_geo_spatial'
 """ Key name for sample geo-spatial data in format of [longitude, latitude] """

--- a/src/loaders/workspace_downloader/workspace_downloader.py
+++ b/src/loaders/workspace_downloader/workspace_downloader.py
@@ -442,14 +442,14 @@ def _retrieve_node_data(
     sample_node = node_tree[0]
 
     meta_controlled = sample_node['meta_controlled']
-    _check_dict_contains(meta_controlled, [names.SAMPLE_LATITUDE, names.SAMPLE_LONGITUDE])
+    _check_dict_contains(meta_controlled, [names.FLD_SAMPLE_LATITUDE, names.FLD_SAMPLE_LONGITUDE])
     for key, meta_value in meta_controlled.items():
         _validate_node_data(key, meta_value)
         node_data[key] = meta_value['value']
 
     # create and add geo-spatial data in the format of [latitude, longitude]
-    node_data[names.SAMPLE_GEO] = [meta_controlled[names.SAMPLE_LATITUDE]['value'],
-                                   meta_controlled[names.SAMPLE_LONGITUDE]['value']]
+    node_data[names.FLD_SAMPLE_GEO] = [meta_controlled[names.FLD_SAMPLE_LATITUDE]['value'],
+                                   meta_controlled[names.FLD_SAMPLE_LONGITUDE]['value']]
 
     return node_data
 
@@ -458,7 +458,7 @@ def _validate_node_data(key, meta_value):
     # validate meta_value for a given key
 
     # validate latitude and longitude sample data
-    if key in [names.SAMPLE_LATITUDE, names.SAMPLE_LONGITUDE]:
+    if key in [names.FLD_SAMPLE_LATITUDE, names.FLD_SAMPLE_LONGITUDE]:
         expected_keys = ['value', 'units']
         _check_dict_keys(meta_value, expected_keys)
 

--- a/src/service/data_products/common_models.py
+++ b/src/service/data_products/common_models.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, validator, Field
 from src.common.storage import collection_and_field_names as names
 from src.service import models
 from src.service import errors
+from typing import Annotated
 
 
 class DBCollection(BaseModel):
@@ -67,65 +68,58 @@ class DataProductSpec(BaseModel):
         arbitrary_types_allowed = True
 
 
-QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE = Query(
+QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE = Annotated[str | None, Query(
     min_length=models.LENGTH_MIN_LOAD_VERSION,
     max_length=models.LENGTH_MAX_LOAD_VERSION,
     regex=models.REGEX_LOAD_VERSION,
     example=models.FIELD_LOAD_VERSION_EXAMPLE,
     description=models.FIELD_LOAD_VERSION_DESCRIPTION + ". This will override the collection's "
         + "load version. Service administrator privileges are required."
-)
+)]
 
 
-QUERY_VALIDATOR_LIMIT = Query(
-    default=1000,
+QUERY_VALIDATOR_LIMIT = Annotated[int, Query(
     ge=1,
     le=1000,
     example=1000,
     description="The maximum number of results"
-)
+)]
 
 
-QUERY_COUNT = Query(
-    default=False,
+QUERY_COUNT = Annotated[bool, Query(
     description="Whether to return the number of records that match the query rather than "
         + "the records themselves. Paging parameters are ignored."
-)
+)]
 
 
-QUERY_MATCH_ID = Query(
-    default = None,
+QUERY_MATCH_ID = Annotated[str | None, Query(
     description="A match ID to set the view to the match rather than "
         + "the entire collection. Authentication is required. If a match ID is "
         # matches are against a specific load version, so...
         + "set, any load version override is ignored. "
         + "If a selection filter and a match filter are provided, they are ANDed together. "
         + "Has no effect on a `count` if `match_mark` is true."
-)
+)]
 
 
-QUERY_MATCH_MARK = Query(
-    default=False,
+QUERY_MATCH_MARK = Annotated[bool, Query(
     description="Whether to mark matched rows rather than filter based on the match ID."
-)
+)]
 
 
-QUERY_SELECTION_ID = Query(
-    default=None,
+QUERY_SELECTION_ID = Annotated[str | None, Query(
     description="A selection ID to set the view to the selection rather than the entire "
         + "collection. If a selection ID is set, any load version override is ignored. "
         + "If a selection filter and a match filter are provided, they are ANDed together. "
         + "Has no effect on a `count` if `selection_mark` is true."
-)
+)]
 
 
-QUERY_SELECTION_MARK = Query(
-    default=False,
+QUERY_SELECTION_MARK = Annotated[bool, Query(
     description="Whether to mark selected rows rather than filter based on the selection ID."
-)
+)]
 
 
-QUERY_STATUS_ONLY = Query(
-    default=False,
+QUERY_STATUS_ONLY = Annotated[bool, Query(
     description="Only return the status of any match or selection processing without any data."
-)
+)]

--- a/src/service/data_products/heatmap.py
+++ b/src/service/data_products/heatmap.py
@@ -197,7 +197,7 @@ class HeatMapController:
         self,
         r: Request,
         collection_id: Annotated[str, PATH_VALIDATOR_COLLECTION_ID],
-        load_ver_override: Annotated[str | None, QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE] = None,
+        load_ver_override: QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE = None,
         user: kb_auth.KBaseUser = Depends(_OPT_AUTH)
     ) -> heatmap_models.HeatMapMeta:
         storage = app_state.get_app_state(r).arangostorage
@@ -215,7 +215,7 @@ class HeatMapController:
             example="4",
             description="The ID of the cell in the heatmap."
         ),
-        load_ver_override: Annotated[str | None, QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE] = None,
+        load_ver_override: QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE = None,
         user: kb_auth.KBaseUser = Depends(_OPT_AUTH)
     ) -> heatmap_models.CellDetail:
         storage = app_state.get_app_state(r).arangostorage
@@ -237,15 +237,15 @@ class HeatMapController:
                 + "parameter can be used to page through the data by providing the ID from "
                 + "the last row in the previous set of data."
         ),
-        limit: int = QUERY_VALIDATOR_LIMIT,
-        count: bool = QUERY_COUNT,
-        match_id: str | None = QUERY_MATCH_ID,
+        limit: QUERY_VALIDATOR_LIMIT = 1000,
+        count: QUERY_COUNT = False,
+        match_id: QUERY_MATCH_ID = None,
         # TODO FEATURE support a choice of AND or OR for matches & selections
-        match_mark: bool = QUERY_MATCH_MARK,
-        selection_id: str | None = QUERY_SELECTION_ID,
-        selection_mark: bool = QUERY_SELECTION_MARK,
-        status_only: bool = QUERY_STATUS_ONLY,
-        load_ver_override: Annotated[str | None, QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE] = None,
+        match_mark: QUERY_MATCH_MARK = False,
+        selection_id: QUERY_SELECTION_ID = None,
+        selection_mark: QUERY_SELECTION_MARK = False,
+        status_only: QUERY_STATUS_ONLY = False,
+        load_ver_override: QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE = None,
         user: kb_auth.KBaseUser = Depends(_OPT_AUTH)
     ) -> Response:
         # For some reason returning the data as a model slows down the endpoint by ~10x.

--- a/src/service/data_products/table_models.py
+++ b/src/service/data_products/table_models.py
@@ -1,0 +1,45 @@
+"""
+Models supporting returning a table of key/value pairs, e.g. genome attributes and samples.
+"""
+
+from pydantic import BaseModel, Field, Extra
+import src.common.storage.collection_and_field_names as names
+from typing import Any
+
+class AttributeName(BaseModel):
+    name: str = Field(
+        example=names.FLD_KBASE_ID,
+        description="The name of an attribute"
+    )
+
+
+class TableAttributes(BaseModel, extra=Extra.allow):
+    """
+    Attributes for a set of data. Either `fields` and `table` are returned, `data` is
+    returned, or `count` is returned.
+    The set of available attributes may be different for different collections.
+    """
+    skip: int = Field(example=0, description="The number of records that were skipped.")
+    limit: int = Field(
+        example=1000,
+        description="The maximum number of results that could be returned. "
+            + "0 and meaningless if `count` is specified"
+    )
+    # may need to return fields with data in the future if we add more info to fields
+    fields: list[AttributeName] | None = Field(
+        description="The name for each column in the attribute table."
+    )
+    table: list[list[Any]] | None = Field(
+        example=[["my_genome_name"]],
+        description="The attributes in an NxM table. Each column's name is available at the "
+            + "corresponding index in the fields parameter. Each inner list is a row in the "
+            + "table with each entry being the entry for that column."
+    )
+    data: list[dict[str, Any]] | None = Field(
+        example=[{names.FLD_KBASE_ID: "assigned_kbase_id"}],
+        description="The attributes as a list of dictionaries."
+    )
+    count: int | None = Field(
+        example=42,
+        description="The number of attribute records that match the query.",
+    )

--- a/src/service/data_products/taxa_count.py
+++ b/src/service/data_products/taxa_count.py
@@ -171,7 +171,7 @@ _FLD_COL_RANK = "rank"
 async def get_ranks(
     r: Request,
     collection_id: str = PATH_VALIDATOR_COLLECTION_ID,
-    load_ver_override: Annotated[str | None, QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE] = None,
+    load_ver_override: QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE = None,
     user: kb_auth.KBaseUser = Depends(_OPT_AUTH)
 ):
     store = app_state.get_app_state(r).arangostorage
@@ -214,8 +214,8 @@ async def get_taxa_counts(
         default = None,
         description="A selection ID to include the selection count in the taxa count data. "
             + "Note that if a selection ID is set, any load version override is ignored."),
-    status_only: bool = QUERY_STATUS_ONLY,
-    load_ver_override: Annotated[str | None, QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE] = None,
+    status_only: QUERY_STATUS_ONLY = False,
+    load_ver_override: QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE = None,
     user: kb_auth.KBaseUser = Depends(_OPT_AUTH)
 ):
     appstate = app_state.get_app_state(r)


### PR DESCRIPTION
Also update shared query specfiers to the new `Annotated` syntax before reusing them with samples