### PR TITLE
RE2022-240: Add identity string filter strategy

### DIFF
--- a/src/common/product_models/columnar_attribs_common_models.py
+++ b/src/common/product_models/columnar_attribs_common_models.py
@@ -36,6 +36,8 @@ class FilterStrategy(str, Enum):
     """
     The strategy for filtering a column if the column type allows for more than one strategy.
     """
+    IDENTITY = "identity"
+    """ A string search based on an exact match to the entire string. """
     PREFIX = "prefix"
     """ A string prefix search. """
     FULL_TEXT = "fulltext"

--- a/src/service/filtering/analyzers.py
+++ b/src/service/filtering/analyzers.py
@@ -36,8 +36,8 @@ _CUSTOM_ANALYZERS = {
     )
 }
 
-def get_analyzer(strategy: FilterStrategy | None):
-    """ Get the appropriate analyer to use for a given filter strategy. """
+def get_analyzer(strategy: FilterStrategy | None) -> str:
+    """ Get the name of the appropriate ArangoDB analyzer to use for a given filter strategy. """
     return _COL2ANALYZER.get(strategy, DEFAULT_ANALYZER)
 
 

--- a/test/src/service/filtering/analyzers_test.py
+++ b/test/src/service/filtering/analyzers_test.py
@@ -8,6 +8,7 @@ def test_get_analyzer():
     test_cases = {
         FilterStrategy.FULL_TEXT: "text_en",
         FilterStrategy.PREFIX: "kbcoll_text_en_prefix",
+        FilterStrategy.IDENTITY: "identity", 
         None: "identity"
     }
     for fs, expected in test_cases.items():


### PR DESCRIPTION
Will want to do exact matches on some columns without stemming, particlarly `kbase_id`