### PR TITLE
RE2022-240: Add arango wrapper functions for dealing with arangosearch views

### DIFF
--- a/src/service/storage_arango.py
+++ b/src/service/storage_arango.py
@@ -266,7 +266,7 @@ class ArangoStorage:
                 name, {"links": {arango_collection: {"fields": view_fields}}}
             )
         except ViewCreateError as e:
-            if e.error_code == ARANGO_ERR_NAME_EXISTS:  # TODO TEST
+            if e.error_code == ARANGO_ERR_NAME_EXISTS:
                 view = await self._db.view(name)
                 if view["links"][arango_collection]["fields"] != view_fields:
                     raise ValueError(f"The view '{name}' already exists and differs from "


### PR DESCRIPTION
```python
In [1]: import aioarango

In [2]: from src.service.storage_arango import ArangoStorage

In [3]: from src.common.collection_column_specs import load_specs

In [4]: from src.service.filtering import analyzers

In [5]: cli = aioarango.ArangoClient(hosts='http://localhost:8529')

In [6]: db = await cli.db("collections_test", username="root",
password="foobar"
   ...: )

In [7]: store = await ArangoStorage.create(db)

In [8]: view_spec = load_specs.load_spec("genome_attribs")

In [9]: try:
   ...:     await store.create_search_view("view_name2",
"kbcoll_genome_attribs"
   ...: , view_spec, analyzers.get_analyzer)
   ...: except Exception as e:
   ...:     print(e)
   ...:
The view 'view_name2' already exists and differs from the requested
specification.

In [10]: await store.create_search_view("new_view",
"kbcoll_genome_attribs", vie
    ...: w_spec, analyzers.get_analyzer)

In [11]: await store.create_search_view("new_view",
"kbcoll_genome_attribs", vie
    ...: w_spec, analyzers.get_analyzer)

In [12]: await store.get_search_views("kbcoll_genome_attribs")
Out[12]: {'new_view', 'view_name', 'view_name2'}

In [13]: await store.get_search_views_from_spec("kbcoll_genome_attribs",
view_sp
    ...: ec, analyzers.get_analyzer)
Out[13]: ['new_view']
```

Tested the following in a later session with the same setup as above:

```python
In [9]: await store.has_search_view("new_view")
Out[9]: True

In [10]: await store.has_search_view("new_view2")
Out[10]: False
```