### PR TITLE
Remove internal fields from genome attribs meta endpoint

### DIFF
--- a/src/common/collection_column_specs/genome_attribs-GTDB.yml
+++ b/src/common/collection_column_specs/genome_attribs-GTDB.yml
@@ -9,7 +9,7 @@ columns:
 
    - key: _mtchsel
      type: string
-     filter_strategy: inarray
+     filter_strategy: identity
 
    - key: kbase_id
      type: string

--- a/src/common/collection_column_specs/genome_attribs-PMI.yml
+++ b/src/common/collection_column_specs/genome_attribs-PMI.yml
@@ -9,7 +9,7 @@ columns:
 
    - key: _mtchsel
      type: string
-     filter_strategy: inarray
+     filter_strategy: identity
 
    - key: kbase_id
      type: string

--- a/src/common/product_models/columnar_attribs_common_models.py
+++ b/src/common/product_models/columnar_attribs_common_models.py
@@ -39,8 +39,6 @@ class FilterStrategy(str, Enum):
     """
     IDENTITY = "identity"
     """ A string search based on an exact match to the entire string. """
-    IN_ARRAY = "inarray"
-    """ A string search based on an exact match to one of a set of entries in an array. """
     PREFIX = "prefix"
     """ A string prefix search. """
     FULL_TEXT = "fulltext"

--- a/src/service/data_products/common_functions.py
+++ b/src/service/data_products/common_functions.py
@@ -69,9 +69,15 @@ def _get_load_ver_from_collection(collection: models.SavedCollection, data_produ
         f"The {collection.id} collection does not have a {data_product} data product registered.")
 
 
+COLLECTION_KEYS = {names.FLD_COLLECTION_ID, names.FLD_LOAD_VERSION}
+"""
+Special keys in data sets that denote the ID and load version of a collection.
+Usually not returned to the user but needed in the database.
+"""
+
 def remove_collection_keys(doc: dict):
     """ Removes the collection ID and load version keys from a dictionary **in place**. """
-    for k in [names.FLD_COLLECTION_ID, names.FLD_LOAD_VERSION]:
+    for k in COLLECTION_KEYS:
         doc.pop(k, None)
     return doc
 

--- a/src/service/data_products/genome_attributes.py
+++ b/src/service/data_products/genome_attributes.py
@@ -20,6 +20,7 @@ from src.service import processing_selections
 from src.service.data_products.common_functions import (
     get_load_version,
     remove_collection_keys,
+    COLLECTION_KEYS,
     count_simple_collection_list,
     mark_data_by_kbase_id,
     remove_marked_subset,
@@ -330,8 +331,11 @@ async def get_genome_attributes_meta(
     ):
     storage = app_state.get_app_state(r).arangostorage
     _, load_ver = await get_load_version(storage, collection_id, ID, load_ver_override, user)
-    return await _get_genome_attributes_meta_internal(
+    meta = await _get_genome_attributes_meta_internal(
         storage, collection_id, load_ver, load_ver_override)
+    meta.columns = [c for c in meta.columns
+                    if c.key not in COLLECTION_KEYS | {names.FLD_MATCHES_SELECTIONS}]
+    return meta
 
 
 async def _get_genome_attributes_meta_internal(

--- a/src/service/filtering/filters.py
+++ b/src/service/filtering/filters.py
@@ -316,9 +316,6 @@ class StringFilter(AbstractFilter):
             case FilterStrategy.IDENTITY:
                 aql_lines=[f"{identifier} == @{bindvar}"]
                 var_assigns = None
-            case FilterStrategy.IN_ARRAY:
-                aql_lines=[f"@{bindvar} IN {identifier}"]
-                var_assigns = None
             case FilterStrategy.FULL_TEXT:
                 aql_lines=[f"ANALYZER({prefixvar} ALL == {identifier}, \"{self.analyzer}\")"]
             case FilterStrategy.PREFIX:

--- a/test/src/common/collection_column_specs/load_specs_test.py
+++ b/test/src/common/collection_column_specs/load_specs_test.py
@@ -50,7 +50,6 @@ def test_all_specs_load_merge():
     
     ident = FilterStrategy.IDENTITY
     ftext = FilterStrategy.FULL_TEXT
-    inar = FilterStrategy.IN_ARRAY
     
     spec = load_specs.load_spec("genome_attribs")
     assert {f.name for f in spec.spec_files} == {
@@ -68,7 +67,7 @@ def test_all_specs_load_merge():
     assert key2spec["translation_table"] == AttributesColumnSpec(
         key="translation_table", type=it)
     assert key2spec["_mtchsel"] == AttributesColumnSpec(
-        key="_mtchsel", type=st, filter_strategy=inar)
+        key="_mtchsel", type=st, filter_strategy=ident)
 
 
 def test_load_single_spec_from_toolchain():

--- a/test/src/service/filtering/analyzers_test.py
+++ b/test/src/service/filtering/analyzers_test.py
@@ -10,7 +10,6 @@ def test_get_analyzer():
         FilterStrategy.FULL_TEXT: "text_en",
         FilterStrategy.PREFIX: "kbcoll_text_en_prefix",
         FilterStrategy.IDENTITY: "identity",
-        FilterStrategy.IN_ARRAY: "identity",
         None: "identity",
     }
     for fs, expected in test_cases.items():
@@ -22,7 +21,6 @@ def test_get_analyzer_return_none():
         FilterStrategy.FULL_TEXT: "text_en",
         FilterStrategy.PREFIX: "kbcoll_text_en_prefix",
         FilterStrategy.IDENTITY: None,
-        FilterStrategy.IN_ARRAY: None,
         None: None,
     }
     for fs, expected in test_cases.items():

--- a/test/src/service/filtering/filters_test.py
+++ b/test/src/service/filtering/filters_test.py
@@ -150,14 +150,6 @@ def test_stringfilter_to_arangosearch_aql_identity():
     )
 
 
-def test_stringfilter_to_arangosearch_aql_in_array():
-    sf = StringFilter.from_string(None, "matchidgoeshere", None, FilterStrategy.IN_ARRAY)
-    assert sf.to_arangosearch_aql("doc._mtchsel", "pre") == SearchQueryPart(
-        aql_lines=["@preinput IN doc._mtchsel"],
-        bind_vars={"preinput": "matchidgoeshere"}
-    )
-
-
 def test_stringfilter_to_arangosearch_aql_full_text():
     _stringfilter_to_arangosearch_aql_full_text(None, "identity")
     _stringfilter_to_arangosearch_aql_full_text("    \t   ", "identity")
@@ -208,7 +200,6 @@ def _filterset_with_defaults_append_filters(fs: FilterSet):
         ).append("fulltextfield", ColumnType.STRING, "whee", "text_rs", FilterStrategy.FULL_TEXT
         ).append("datefield", ColumnType.DATE, ",2023-09-13T18:51:19+0000]"
         ).append("strident", ColumnType.STRING, "thingy", strategy=FilterStrategy.IDENTITY
-        ).append("_mtchsel", ColumnType.STRING, "mtchid", strategy=FilterStrategy.IN_ARRAY
     )
     return fs
 
@@ -238,8 +229,6 @@ FOR doc IN @@view
         doc.datefield <= @v5_high
         AND
         doc.strident == @v6_input
-        AND
-        @v7_input IN doc._mtchsel
     )
     LIMIT @skip, @limit
     RETURN doc
@@ -257,9 +246,8 @@ FOR doc IN @@view
         "v4_input": "whee",
         "v5_high": "2023-09-13T18:51:19+0000",
         "v6_input": "thingy",
-        "v7_input": "mtchid",
     }
-    assert len(fs) == 7
+    assert len(fs) == 6
 
 
 def test_filterset_w_defaults_count():
@@ -288,8 +276,6 @@ RETURN COUNT(FOR doc IN @@view
         doc.datefield <= @v5_high
         AND
         doc.strident == @v6_input
-        AND
-        @v7_input IN doc._mtchsel
     )
     RETURN doc
 )
@@ -305,9 +291,8 @@ RETURN COUNT(FOR doc IN @@view
         "v4_input": "whee",
         "v5_high": "2023-09-13T18:51:19+0000",
         "v6_input": "thingy",
-        "v7_input": "mtchid",
     }
-    assert len(fs) == 7
+    assert len(fs) == 6
 
 
 def test_filterset_w_all_args():


### PR DESCRIPTION
`load_ver` shouldn't be exposed to users here and `coll` is redundant. Also remove the `inarray` filter strategy as arangosearch treats arrays and strings effectively identically when it comes to matching, so there's no need for it