### PR TITLE
explicitly provide ipv4 to callback server

### DIFF
--- a/src/loaders/workspace_downloader/workspace_downloader_helper.py
+++ b/src/loaders/workspace_downloader/workspace_downloader_helper.py
@@ -46,6 +46,7 @@ class Conf:
         token = loader_helper.get_token(token_filepath)
         self.retrieve_sample = retrieve_sample
         self.ignore_no_sample_error = ignore_no_sample_error
+        self.ipv4 = loader_helper.get_ip()
         self._start_callback_server(
             docker.from_env(),
             uuid.uuid4().hex,
@@ -53,11 +54,12 @@ class Conf:
             kb_base_url,
             token,
             port,
+            self.ipv4,
         )
 
         ws_url = os.path.join(kb_base_url, "ws")
         sample_url = os.path.join(kb_base_url, "sampleservice")
-        callback_url = "http://" + loader_helper.get_ip() + ":" + str(port)
+        callback_url = "http://" + self.ipv4  + ":" + str(port)
         print("callback_url:", callback_url)
 
         self.ws = Workspace(ws_url, token=token)
@@ -77,6 +79,7 @@ class Conf:
             kb_base_url: str,
             token: str,
             port: int,
+            ipv4: str,
     ) -> Tuple[dict[str, Union[int, str]], dict[str, dict[str, str]]]:
         """
         Setup the environment variables and volumes for the callback server.
@@ -99,6 +102,8 @@ class Conf:
         env["KB_BASE_URL"] = kb_base_url
         env["JOB_DIR"] = job_dir
         env["CALLBACK_PORT"] = port
+        env["CALLBACK_IP"] = ipv4  # specify an ipv4 address for the callback server
+                                   # otherwise, the callback container will use the an ipv6 address
 
         # setup volumes required for docker container
         docker_host = os.environ["DOCKER_HOST"]
@@ -118,6 +123,7 @@ class Conf:
             kb_base_url: str,
             token: str,
             port: int,
+            ipv4: str,
     ) -> None:
         """
         Start the callback server.
@@ -130,7 +136,7 @@ class Conf:
             token (str): The KBase token.
             port (int): The port number for the callback server.
         """
-        env, vol = self._setup_callback_server_envs(job_dir, kb_base_url, token, port)
+        env, vol = self._setup_callback_server_envs(job_dir, kb_base_url, token, port, ipv4)
         self.container = client.containers.run(
             name=container_name,
             image=CALLBACK_IMAGE_NAME,

--- a/src/loaders/workspace_downloader/workspace_downloader_helper.py
+++ b/src/loaders/workspace_downloader/workspace_downloader_helper.py
@@ -46,7 +46,7 @@ class Conf:
         token = loader_helper.get_token(token_filepath)
         self.retrieve_sample = retrieve_sample
         self.ignore_no_sample_error = ignore_no_sample_error
-        self.ipv4 = loader_helper.get_ip()
+        ipv4 = loader_helper.get_ip()
         self._start_callback_server(
             docker.from_env(),
             uuid.uuid4().hex,
@@ -54,12 +54,12 @@ class Conf:
             kb_base_url,
             token,
             port,
-            self.ipv4,
+            ipv4,
         )
 
         ws_url = os.path.join(kb_base_url, "ws")
         sample_url = os.path.join(kb_base_url, "sampleservice")
-        callback_url = "http://" + self.ipv4  + ":" + str(port)
+        callback_url = "http://" + ipv4 + ":" + str(port)
         print("callback_url:", callback_url)
 
         self.ws = Workspace(ws_url, token=token)


### PR DESCRIPTION
without explicitly provide `CALLBACK_IP`, the jobrunner container will return an ipv6 address. 

But the JobRunner code should return an IPV4 instead. I am not sure if it has something to do with how the image was built (there is no dockerfile in that repo). 
https://github.com/kbase/JobRunner/blob/master/JobRunner/JobRunner.py#L202-L204

```
(base) tgu@login39 tgu  $ podman run --name tian_callback -it --rm \
> --net host \
> -e KB_* \
> -e CALLBACK_PORT=9999 \
> -e KB_AUTH_TOKEN=$KB_AUTH_TOKEN \
> -e KB_BASE_URL=https://ci.kbase.us/services/ \
> -e JOB_DIR \
> -e DEBUG_MODE=true \
> -v $JOB_DIR:$JOB_DIR \
> kbase/callback:test
WARN[0000] Path "/etc/SUSEConnect" from "/etc/containers/mounts.conf" doesn't exist, skipping 
WARN[0000] Path "/etc/zypp/credentials.d/SCCcredentials" from "/etc/containers/mounts.conf" doesn't exist, skipping 
Warning: Missing admin token needed for volume mounts.
INFO:jr:Logger initialized for test
Callback IP provided (2620:0:28b0:64:0:ff:fe00:31f)
Job runner recieved Callback URL http://2620:0:28b0:64:0:ff:fe00:31f:9999/
```