### PR TITLE
Refactor filters.py to generate AQL

### DIFF
--- a/src/service/filtering/filters.py
+++ b/src/service/filtering/filters.py
@@ -491,8 +491,6 @@ class FilterSet:
         if not self.collection:
             raise ValueError("If no filters are added to the filter set the collection argument "
                 + "is required in the constructor")
-        if self.start_after and not self.sort_on:
-            raise ValueError("If start_aftger ")
         bind_vars = {
             "@collection": self.collection,
             "collid": self.collection_id,

--- a/src/service/filtering/filters.py
+++ b/src/service/filtering/filters.py
@@ -17,6 +17,9 @@ from src.service.filtering.analyzers import DEFAULT_ANALYZER
 from src.service.processing import SubsetSpecification
 
 
+_PARTICLES_IN_UNIVERSE = 10 ** 80
+
+
 class SearchQueryPart(BaseModel):
     variable_assignments: Annotated[dict[str, str] | None, Field(
         description="A mapping of variable name to AQL expression. The variables must be assigned "
@@ -75,8 +78,10 @@ def _to_bool_string(b: bool):
     return "true" if b else "false"
 
 
-def _require_string(s: str, err: str):
+def _require_string(s: str, err: str, optional: bool = False):
     if not s or not s.strip():
+        if optional:
+            return None
         raise errors.MissingParameterError(err)
     return s.strip()
 
@@ -336,7 +341,7 @@ class StringFilter(AbstractFilter):
 
 class FilterSet:
     """
-    A set of filters that can be translated into ArangoSearch AQL.
+    A set of filters that can be translated into AQL.
     """
 
     _FILTER_MAP = {
@@ -348,10 +353,12 @@ class FilterSet:
     
     def __init__(
         self,
-        view: str,
         collection_id: str,
         load_ver: str,
+        view: str = None,
+        collection: str = None,
         count: bool = False,
+        start_after: str = None,
         sort_on: str = None,
         sort_descending: bool = False,
         conjunction: bool = True,
@@ -364,30 +371,46 @@ class FilterSet:
         """
         Create the filter set.
         
-        view - the ArangoSearch view to query.
         collection_id - the ID of the KBase collection to query.
         load_ver - the load version of the data to query.
+        view - the ArangoSearch view to query. Required if any filters are added to this filter
+            set, as therefore ArangoSearch will be used for the query.
+        collection - the Arango collection to query. Required if no filters are added to this
+            filter set, as therefore a standard Arango AQL query will be used.
         count - return the total document count rather than the documents. This may cause a
             large view scan.
         sort_on - the field on which to sort, if any.
         sort_descending - sort in the descending direction vs. ascending.
         conjunction - whether to AND (true) or OR (false) the filters together.
+        start_after - skip any records prior to and including this value in the `sort_on` field,
+            which should contain unique values.
+            It is strongly recommended to set up an index that the query can use to skip to
+            the correct starting record without a table scan. This parameter allows for
+            non-O(n^2) paging of data.
+            start_after is not currently implemented for the case where any filters are appended.
         skip - the number of records to skip. Use this parameter wisely, as paging
             through records via increasing skip incrementally is an O(n^2) operation.
-        limit - the maximum number of records to return.
+        limit - the maximum number of records to return. 0 indicates no limit, which is usually
+            a bad idea.
         doc_var - the variable to use for the ArangoSearch document.
         """
-        self.view = _require_string(view, "view is required")
         self.collection_id = _require_string(collection_id, "collection_id is required")
         self.load_ver = _require_string(load_ver, "load_ver is required")
+        self.view = _require_string(view, "view", True)
+        self.collection = _require_string(collection, "collection", True)
+        if not self.view and not self.collection:
+            raise ValueError("At least one of a view or a collection is required")
         self.count = count
-        self.sort_on = sort_on
+        self.sort_on = _require_string(sort_on, "sort_on", True)
         self.sort_descending = sort_descending
         self.conjunction = conjunction
         self.match_spec = match_spec
         self.selection_spec = selection_spec
+        self.start_after = _require_string(start_after, "start_after", True)
+        if self.start_after and not self.sort_on:
+            raise ValueError("If start_after is supplied sort_on must be supplied")
         self.skip = _gt(skip, 0, "skip")
-        self.limit = _gt(limit, 1, "limit")
+        self.limit = _gt(limit, 0, "limit")
         self.doc_var = _require_string(doc_var, "doc_var is required")
         self._filters = {}
 
@@ -455,13 +478,71 @@ class FilterSet:
             bind_vars.update(search_part.bind_vars)
         return var_lines, aql_lines, bind_vars
 
-    def to_arangosearch_aql(self) -> tuple[str, dict[str, Any]]:
+    def to_aql(self) -> tuple[str, dict[str, Any]]:
         """
-        Generate ArangoSearch AQL and bind vars from the filters. At least one filter must have
-        been added to the filter set prior to calling this method.
+        Generate Arango AQL and bind vars from the filters.
         """
-        if not self._filters:
-            raise ValueError("At least one filter is required")
+        if self._filters:
+            return self._to_arangosearch_aql()
+        else:
+            return self._to_standard_aql()
+        
+    def _to_standard_aql(self):
+        if not self.collection:
+            raise ValueError("If no filters are added to the filter set the collection argument "
+                + "is required in the constructor")
+        if self.start_after and not self.sort_on:
+            raise ValueError("If start_aftger ")
+        bind_vars = {
+            "@collection": self.collection,
+            "collid": self.collection_id,
+            "load_ver": self.load_ver,
+        }
+        aql = f"FOR {self.doc_var} IN @@collection\n"
+        aql += f"    FILTER {self.doc_var}.{names.FLD_COLLECTION_ID} == @collid\n"
+        aql += f"    FILTER {self.doc_var}.{names.FLD_LOAD_VERSION} == @load_ver\n"
+        if self.match_spec.get_subset_filtering_id():
+            bind_vars["internal_match_id"] = self.match_spec.get_subset_filtering_id()
+            aql += (f"    FILTER {self.doc_var}.{names.FLD_MATCHES_SELECTIONS} == "
+                    + "@internal_match_id\n")
+        if self.selection_spec.get_subset_filtering_id():
+            bind_vars["internal_selection_id"] = self.selection_spec.get_subset_filtering_id()
+            aql += (f"    FILTER {self.doc_var}.{names.FLD_MATCHES_SELECTIONS} == "
+                    + "@internal_selection_id\n")
+        if self.start_after:
+            aql += f"    FILTER d.@sort > @start_after\n"
+            bind_vars["start_after"] = self.start_after
+        if self.count:
+            aql += "    COLLECT WITH COUNT INTO length\n"
+            aql += "    RETURN length\n"
+        else:
+            ssl_aql, ssl_bind_vars = self._sort_skip_limit()
+            aql += ssl_aql
+            bind_vars |= ssl_bind_vars
+            aql += f"    RETURN {self.doc_var}\n"
+        return aql, bind_vars
+
+    def _sort_skip_limit(self) -> (str, dict[str, Any]):
+        aql = ""
+        bind_vars = {}
+        if self.sort_on:
+            aql += f"    SORT {self.doc_var}.@sort @sortdir\n"
+            bind_vars |= {
+                "sort": self.sort_on,
+                "sortdir": "DESC" if self.sort_descending else "ASC"
+            }
+        if self.skip or self.limit:
+            aql += f"    LIMIT @skip, @limit\n"
+            bind_vars |= {
+                "skip": self.skip,
+                "limit": self.limit if self.limit > 0 else _PARTICLES_IN_UNIVERSE
+            }
+        return aql, bind_vars
+
+    def _to_arangosearch_aql(self):
+        if not self.view:
+            raise ValueError("If a filter is added to the filter set the view argument is "
+                + "required in the constructor")
         var_lines, aql_lines, bind_vars = self._process_filters()
         aql = ""
         if var_lines:
@@ -489,14 +570,9 @@ class FilterSet:
         aql += f"\n        {op}\n    ".join(aql_parts)
         aql += f"\n    )\n"
         if not self.count:
-            if self.sort_on:
-                aql += f"    SORT {self.doc_var}.@sort @sortdir\n"
-                bind_vars |= {
-                    "sort": self.sort_on,
-                    "sortdir": "DESC" if self.sort_descending else "ASC"
-                }
-            aql += f"    LIMIT @skip, @limit\n"
-            bind_vars |= {"skip": self.skip, "limit": self.limit}
+            ssl_aql, ssl_bind_vars = self._sort_skip_limit()
+            aql += ssl_aql
+            bind_vars |= ssl_bind_vars
         # should check if there's a way to speed up counts by returning less stuff or if
         # the query optimizer is smart enough to just do the count and things are fine as is
         aql += f"    RETURN {self.doc_var}\n"

--- a/test/src/service/filtering/filters_test.py
+++ b/test/src/service/filtering/filters_test.py
@@ -204,10 +204,11 @@ def _filterset_with_defaults_append_filters(fs: FilterSet):
     return fs
 
 
-def test_filterset_w_defaults():
-    fs = _filterset_with_defaults_append_filters(FilterSet("my_search_view", "coll24", "loadver9"))
+def test_filterset_arangosearch_w_defaults():
+    fs = _filterset_with_defaults_append_filters(FilterSet(
+        "coll24", "loadver9", view="my_search_view"))
 
-    aql, bind_vars = fs.to_arangosearch_aql()
+    aql, bind_vars = fs.to_aql()
     
     assert aql == """
 LET v2_prefixes = TOKENS(@v2_input, "text_en")
@@ -250,11 +251,32 @@ FOR doc IN @@view
     assert len(fs) == 6
 
 
-def test_filterset_w_defaults_count():
-    fs = _filterset_with_defaults_append_filters(
-        FilterSet("my_search_view", "coll24", "loadver9", count=True))
+def test_filterset_aql_w_defaults():
+    fs = FilterSet("coll24", "loadver9", collection="my_coll")
 
-    aql, bind_vars = fs.to_arangosearch_aql()
+    aql, bind_vars = fs.to_aql()
+    
+    assert aql == """
+FOR doc IN @@collection
+    FILTER doc.coll == @collid
+    FILTER doc.load_ver == @load_ver
+    LIMIT @skip, @limit
+    RETURN doc
+""".strip() + "\n"
+    assert bind_vars == {
+        "@collection": "my_coll",
+        "collid": "coll24",
+        "load_ver": "loadver9",
+        "skip": 0,
+        "limit": 1000,
+    }
+    assert len(fs) == 0
+
+def test_filterset_arangosearch_w_defaults_count():
+    fs = _filterset_with_defaults_append_filters(
+        FilterSet("coll24", "loadver9", view="my_search_view", count=True))
+
+    aql, bind_vars = fs.to_aql()
     
     assert aql == """
 LET v2_prefixes = TOKENS(@v2_input, "text_en")
@@ -295,11 +317,31 @@ RETURN COUNT(FOR doc IN @@view
     assert len(fs) == 6
 
 
-def test_filterset_w_all_args():
+def test_filterset_aql_w_defaults_count():
+    fs = FilterSet("coll24", "loadver9", collection="my_coll", count=True)
+
+    aql, bind_vars = fs.to_aql()
+    
+    assert aql == """
+FOR doc IN @@collection
+    FILTER doc.coll == @collid
+    FILTER doc.load_ver == @load_ver
+    COLLECT WITH COUNT INTO length
+    RETURN length
+""".strip() + "\n"
+    assert bind_vars == {
+        "@collection": "my_coll",
+        "collid": "coll24",
+        "load_ver": "loadver9",
+    }
+    assert len(fs) == 0
+    
+
+def test_filterset_arangosearch_w_all_args():
     fs = FilterSet(
-        "my_other_search_view",
         "mycollection",
         "loadver6",
+        view="my_other_search_view",
         sort_on="sortfield",
         sort_descending=True,
         conjunction=False,
@@ -311,7 +353,7 @@ def test_filterset_w_all_args():
     )
     fs.append("rangefield", ColumnType.INT, "[-2,6]")
     fs.append("prefixfield", ColumnType.STRING, "thingy", "text_en", FilterStrategy.PREFIX)
-    aql, bind_vars = fs.to_arangosearch_aql()
+    aql, bind_vars = fs.to_aql()
     
     assert aql == """
 LET v2_prefixes = TOKENS(@v2_input, "text_en")
@@ -350,11 +392,54 @@ FOR d IN @@view
     assert len(fs) == 2
 
 
-def test_filterset_w_all_args_count():
+def test_filterset_aql_w_all_args():
     fs = FilterSet(
-        "my_other_search_view",
         "mycollection",
         "loadver6",
+        collection="my_arango_collection",
+        sort_on="sortfield",
+        sort_descending=True,
+        conjunction=False,
+        match_spec=SubsetSpecification(internal_subset_id="matchy", prefix="m_"),
+        selection_spec=SubsetSpecification(internal_subset_id="selly", prefix="s_"),
+        start_after="a_unique_field",
+        skip=24,
+        limit=2,
+        doc_var="d",
+    )
+    aql, bind_vars = fs.to_aql()
+    
+    assert aql == """
+FOR d IN @@collection
+    FILTER d.coll == @collid
+    FILTER d.load_ver == @load_ver
+    FILTER d._mtchsel == @internal_match_id
+    FILTER d._mtchsel == @internal_selection_id
+    FILTER d.@sort > @start_after
+    SORT d.@sort @sortdir
+    LIMIT @skip, @limit
+    RETURN d
+""".strip() + "\n"
+    assert bind_vars == {
+        "@collection": "my_arango_collection",
+        "collid": "mycollection",
+        "load_ver": "loadver6",
+        "sort": "sortfield",
+        "sortdir":"DESC",
+        "internal_match_id": "m_matchy",
+        "internal_selection_id": "s_selly",
+        'start_after': 'a_unique_field',
+        "skip": 24,
+        "limit": 2,
+    }
+    assert len(fs) == 0
+
+
+def test_filterset_arangosearch_w_all_args_count():
+    fs = FilterSet(
+        "mycollection",
+        "loadver6",
+        view="my_other_search_view",
         sort_on="sortfield",  # should be ignored
         sort_descending=True,
         count=True,
@@ -367,7 +452,7 @@ def test_filterset_w_all_args_count():
     )
     fs.append("rangefield", ColumnType.INT, "[-2,6]")
     fs.append("prefixfield", ColumnType.STRING, "thingy", "text_en", FilterStrategy.PREFIX)
-    aql, bind_vars = fs.to_arangosearch_aql()
+    aql, bind_vars = fs.to_aql()
     
     assert aql == """
 LET v2_prefixes = TOKENS(@v2_input, "text_en")
@@ -398,15 +483,53 @@ RETURN COUNT(FOR d IN @@view
     assert len(fs) == 2
 
 
-def test_filterset_sort_asc():
+def test_filterset_aql_w_all_args_count():
     fs = FilterSet(
-        "sorty_sort",
+        "mycollection",
+        "loadver6",
+        collection="my_arango_collection",
+        sort_on="sortfield",
+        sort_descending=True,
+        count=True,
+        conjunction=False,
+        match_spec=SubsetSpecification(internal_subset_id="matchy", prefix="m_"),
+        selection_spec=SubsetSpecification(internal_subset_id="selly", prefix="s_"),
+        skip=24,
+        limit=2,
+        doc_var="d",
+    )
+    aql, bind_vars = fs.to_aql()
+    
+    assert aql == """
+FOR d IN @@collection
+    FILTER d.coll == @collid
+    FILTER d.load_ver == @load_ver
+    FILTER d._mtchsel == @internal_match_id
+    FILTER d._mtchsel == @internal_selection_id
+    COLLECT WITH COUNT INTO length
+    RETURN length
+""".strip() + "\n"
+    assert bind_vars == {
+        "@collection": "my_arango_collection",
+        "collid": "mycollection",
+        "load_ver": "loadver6",
+        "internal_match_id": "m_matchy",
+        "internal_selection_id": "s_selly",
+    }
+    assert len(fs) == 0
+
+
+def test_filterset_arangosearch_sort_asc_and_limit_0():
+    fs = FilterSet(
         "sortcol",
         "loadver89",
-        sort_on="somefield",  # should be ignored
+        view="sorty_sort",
+        sort_on="somefield",
+        skip=1,
+        limit=0,
     )
     fs.append("rangefield", ColumnType.INT, "[-2,6]")
-    aql, bind_vars = fs.to_arangosearch_aql()
+    aql, bind_vars = fs.to_aql()
     assert aql == """
 FOR doc IN @@view
     SEARCH (
@@ -426,22 +549,54 @@ FOR doc IN @@view
         "load_ver": "loadver89",
         "sort": "somefield",
         "sortdir": "ASC",
-        "skip": 0,
-        "limit": 1000,
+        "skip": 1,
+        "limit": 100000000000000000000000000000000000000000000000000000000000000000000000000000000,
         'v1_low': -2.0,
         'v1_high': 6.0,
     }
     assert len(fs) == 1
 
 
-def test_filterset_w_1_filter():
+def test_filterset_aql_sort_asc_and_limit_0():
     fs = FilterSet(
-        "so_many_search_views",
+        "sortcol",
+        "loadver89",
+        collection="sorty_sort",
+        sort_on="somefield",
+        skip=1,
+        limit=0,
+    )
+    aql, bind_vars = fs.to_aql()
+    assert aql == """
+FOR doc IN @@collection
+    FILTER doc.coll == @collid
+    FILTER doc.load_ver == @load_ver
+    SORT doc.@sort @sortdir
+    LIMIT @skip, @limit
+    RETURN doc
+""".strip() + "\n"
+    assert bind_vars == {
+        "@collection": "sorty_sort",
+        "collid": "sortcol",
+        "load_ver": "loadver89",
+        "sort": "somefield",
+        "sortdir": "ASC",
+        "skip": 1,
+        "limit": 100000000000000000000000000000000000000000000000000000000000000000000000000000000,
+    }
+    assert len(fs) == 0
+
+
+def test_filterset_arangosearch_w_1_filter_and_0_skip_limit():
+    fs = FilterSet(
         "PMI",
         "loadyload",
+        view="so_many_search_views",
+        skip=0,
+        limit=0,
     )
     fs.append("shoe_size", ColumnType.FLOAT, "[-56.9, 32.1)")
-    aql, bind_vars = fs.to_arangosearch_aql()
+    aql, bind_vars = fs.to_aql()
     
     assert aql == """
 FOR doc IN @@view
@@ -452,44 +607,70 @@ FOR doc IN @@view
     ) AND (
         IN_RANGE(doc.shoe_size, @v1_low, @v1_high, true, false)
     )
-    LIMIT @skip, @limit
     RETURN doc
 """.strip() + "\n"
     assert bind_vars == {
         "@view": "so_many_search_views",
         "collid": "PMI",
         "load_ver": "loadyload",
-        "skip": 0,
-        "limit": 1000,
         'v1_low': -56.9,
         'v1_high': 32.1,
     }
     assert len(fs) == 1
 
 
-def test_filterset_len_0():
-    assert len(FilterSet("v", "c", "lv")) == 0
+def test_filterset_aql_w_1_filter_and_0_skip_limit():
+    fs = FilterSet(
+        "PMI",
+        "loadyload",
+        collection="so_many_collections",
+        skip=0,
+        limit=0,
+    )
+    aql, bind_vars = fs.to_aql()
+    
+    assert aql == """
+FOR doc IN @@collection
+    FILTER doc.coll == @collid
+    FILTER doc.load_ver == @load_ver
+    RETURN doc
+""".strip() + "\n"
+    assert bind_vars == {
+        "@collection": "so_many_collections",
+        "collid": "PMI",
+        "load_ver": "loadyload",
+    }
+    assert len(fs) == 0
 
 
 def test_filterset_fail_construct():
     m = errors.MissingParameterError
     i = errors.IllegalParameterError
-    _filterset_fail_construct(None, "c", "lv", 0, 1, "d", m, "view is required")
-    _filterset_fail_construct("   \t  ", "c", "lv", 0, 1, "d", m, "view is required")
-    _filterset_fail_construct("v", None, "lv", 0, 1, "d", m, "collection_id is required")
-    _filterset_fail_construct("v", "    \t   ", "lv", 0, 1, "d", m, "collection_id is required")
-    _filterset_fail_construct("v", "c", None, 0, 1, "d", m, "load_ver is required")
-    _filterset_fail_construct("v", "c", "  \t  ", 0, 1, "d", m, "load_ver is required")
-    _filterset_fail_construct("v", "c", "lv", 0, 1, None, m, "doc_var is required")
-    _filterset_fail_construct("v", "c", "lv", 0, 1, "   \t   ", m, "doc_var is required")
-    _filterset_fail_construct("v", "c", "lv", -1, 1, "d", i, "skip must be >= 0")
-    _filterset_fail_construct("v", "c", "lv", 1, 0, "d", i, "limit must be >= 1")
+    v = ValueError
+    n = None
+    _filterset_fail_construct(n, "lv", "v", "c", n, 0, 1, "d", m, "collection_id is required")
+    _filterset_fail_construct("    \t   ", "lv", "v", "c", n, 0, 1, "d", m,
+                              "collection_id is required")
+    _filterset_fail_construct("c", n, "v", "c", n, 0, 1, "d", m, "load_ver is required")
+    _filterset_fail_construct("c", "  \t  ", "v", "c", n, 0, 1, "d", m, "load_ver is required")
+    _filterset_fail_construct("c", "lv", n, n, n, 0, 1, "d", v,
+                              "At least one of a view or a collection is required")
+    _filterset_fail_construct("c", "lv", "   \t  ", "   \t  ", n, 0, 1, "d", v,
+                              "At least one of a view or a collection is required")
+    _filterset_fail_construct("c", "lv", "v", "c", "start", 1, 1, "d", v,
+                              "If start_after is supplied sort_on must be supplied")
+    _filterset_fail_construct("c", "lv", "v", "c", n, -1, 1, "d", i, "skip must be >= 0")
+    _filterset_fail_construct("c", "lv", "v", "c", n, 1, -1, "d", i, "limit must be >= 0")
+    _filterset_fail_construct("c", "lv", "v", "c", n, 0, 1, n, m, "doc_var is required")
+    _filterset_fail_construct("c", "lv", "v", "c", n, 0, 1, "   \t   ", m, "doc_var is required")
 
 
 def _filterset_fail_construct(
-        view: str,
         coll_id: str,
         load_ver: str,
+        view: str,
+        coll: str,
+        start_after: str,
         skip: int,
         limit: int,
         doc_var: str,
@@ -497,7 +678,9 @@ def _filterset_fail_construct(
         expected: str
     ):
     with raises(errclass, match=f"^{re.escape(expected)}$"):
-        FilterSet(view, coll_id, load_ver, skip=skip, limit=limit, doc_var=doc_var)
+        FilterSet(
+            coll_id, load_ver, view=view, collection=coll, start_after=start_after,
+            skip=skip, limit=limit, doc_var=doc_var)
 
 
 def test_filterset_fail_append():
@@ -531,18 +714,27 @@ def _filterset_fail_append(
         expected: str
     ):
     with raises(errclass, match=f"^{re.escape(expected)}$"):
-        FilterSet("v", "c", "lv").append(field, coltype, string, None, strategy)
+        FilterSet("c", "lv", view="v").append(field, coltype, string, None, strategy)
 
 
 def test_filterset_fail_append_duplicate_field():
     expected = "Filter for field myfield was provided more than once"
     with raises(errors.IllegalParameterError, match=f"^{re.escape(expected)}$"):
-        FilterSet("v", "c", "lv"
+        FilterSet("c", "lv", view="v"
             ).append("myfield", ColumnType.INT, "8,"
             ).append("myfield", ColumnType.STRING, "foo", "text_en", FilterStrategy.FULL_TEXT)
 
 
-def test_filterset_fail_to_arangosearch_aql():
-    expected = "At least one filter is required"
+def test_filterset_fail_to_aql_std_aql():
+    expected = ("If no filters are added to the filter set the collection argument is required "
+                + "in the constructor")
     with raises(ValueError, match=f"^{re.escape(expected)}$"):
-        FilterSet("v", "c", "lv").to_arangosearch_aql()
+        FilterSet("c", "lv", view="v").to_aql()
+
+def test_filterset_fail_to_aql_arangosearch_aql():
+    expected = ("If a filter is added to the filter set the view argument is required "
+                + "in the constructor")
+    with raises(ValueError, match=f"^{re.escape(expected)}$"):
+        FilterSet("c", "lv", collection="c"
+            ).append("myfield", ColumnType.INT, "[1,"
+            ).to_aql()


### PR DESCRIPTION
as well as ArangoSearch. This'll allow us to put the table search aql generation code in one place instead of the current 3 and abstract away the difference between arangosearch and regular queries.

Next step is updating the code to use the filterset everywhere tables are queried.