### PR TITLE
RE2022-247: skip ani screen

### DIFF
--- a/src/loaders/compute_tools/gtdb_tk/versions.yaml
+++ b/src/loaders/compute_tools/gtdb_tk/versions.yaml
@@ -24,3 +24,8 @@ versions:
       - update GTDB-Tk version to 2.3.2
       - use reference data from release 214
     reference_db_version: release214
+  - version: 0.1.4
+    date: 2023-11-01
+    notes: |
+      - using --skip_ani_screen option to skip pre ANI screening step to improve performance
+    reference_db_version: release214


### PR DESCRIPTION
NERSC experiences timeouts with the latest `--mash_db` option. 

- Initially, GROW/ENIGMA jobs experienced timeouts but succeeded upon rerun.
- PMI consistently encountered timeouts.

logs are indicating the app was stuck at:
[2023-11-01 18:27:19] INFO: Calculating Mash distances.
[2023-11-01 18:29:11] INFO: Calculating ANI with FastANI v1.32.

According to GTDB-TK doc, `The --skip_ani_screen option will skip the pre-screening step and classify all genomes similar to previous versions of GTDB-Tk.`

To enhance performance, we can omit this step. Also considering that we already executed Mash as an additional tool.

GTDB-Tk on PMI collections was completed in approximately 4 hours with `skip_ani_screen` option. 