### PR TITLE
RE2022-268: Add basic provenance information when saving sets

### DIFF
--- a/src/service/routes_collections.py
+++ b/src/service/routes_collections.py
@@ -212,6 +212,7 @@ class SelectionTypes(BaseModel):
 class SetSaveInformation(BaseModel):
     """ Information to provide when saving a set. """
     description: str | None = Field(
+        max_length=800,
         description="An arbitrary description of a set, no more than 800 bytes."
     )
 
@@ -428,7 +429,15 @@ async def create_sets(
     desc = setinfo.description if setinfo else None
     appstate = app_state.get_app_state(r)
     upa, type_ = await processing_selections.save_set_to_workspace(
-        appstate, selection_id, user, workspace_id, object_name, ws_type, desc)
+        appstate,
+        selection_id,
+        user,
+        workspace_id,
+        object_name,
+        ws_type,
+        service_ver=VERSION,
+        description=desc,
+    )
     return CreatedSet(set=WorkspaceSet(upa=upa, type=type_))
 
 

--- a/src/service/workspace_wrapper.py
+++ b/src/service/workspace_wrapper.py
@@ -3,8 +3,8 @@ Wrapper for a workspace client that provides a simplified interface for the need
 collections service.
 """
 
+from typing import Any, Iterable, Annotated
 from pydantic import BaseModel, Field
-from typing import Any, Iterable
 from src.service import errors
 from src.service.sdk_async_client import SDKAsyncClient, ServerError
 
@@ -37,6 +37,10 @@ class SetSpec(BaseModel):
     upas: list[str] = Field(description="The UPAs of the objects making up the set")
     upa_type: str = Field(description="The type of the objects in the UPA list")
     description: str | None = Field(description="A description of the set")
+    provenance: Annotated[dict[str, Any], Field(
+        description="The workspace provenance action for the set, if any. "
+            + "Multiple provenance actions are not supported."
+    )] = None 
 
 
 class WorkspaceWrapper:
@@ -201,7 +205,9 @@ class WorkspaceWrapper:
                 "name": s.name,
                 "type": setinfo["type"],
                 "data": wsset,
-                "provenance": [{"description": "Saved by the KBase collections service."}]
+                # might want to do some error checking here or make a provenance data structure...
+                # YAGNI for now
+                "provenance": [s.provenance],
             })
         try:
             res = await self._cli.call(


### PR DESCRIPTION
... as per /design/provenance.md

Also throw an error if the description is > 800 chars

Match information is still do do