### PR TITLE
RE2022-268: Allow specifying a match when saving a selection as a workspace set

### DIFF
--- a/src/service/app_state.py
+++ b/src/service/app_state.py
@@ -37,7 +37,9 @@ async def build_app(
     data_products - the data products installed in the system
     matchers - the matchers installed in the system
     """
+    print("Connecting to KBase auth service... ", end="", flush=True)
     auth = await KBaseAuth.create(cfg.auth_url, cfg.auth_full_admin_roles)
+    print("Done")
     sdk_client = SDKAsyncClient(cfg.workspace_url)
     cli = None
     try:
@@ -86,6 +88,7 @@ def _get_app_state_from_app(app: FastAPI) -> CollectionsState:
 
 
 async def _check_workspace_url(sdk_cli: SDKAsyncClient, ws_url: str) -> str:
+    print("Connecting to KBase workspace service... ", flush=True)
     try:
         ver = await sdk_cli.call("Workspace.ver")
         # could check the version later if we add dependencies on newer versions

--- a/src/service/routes_collections.py
+++ b/src/service/routes_collections.py
@@ -422,12 +422,22 @@ async def create_sets(
         min_length=1,
         max_length=255,
     ),
-    user: kb_auth.KBaseUser=Depends(_AUTH),
+    # TODO SELECTION allow recording a match ID when making a selection or
+    #                making a selection directly from a match?
+    #                This'll work for now, improve later. Will complicate match / selection
+    #                expiration a lot - should the match expire if a selection points to it?
+    #                Maybe just record match params, matcher_id, & whether
+    #                selection_ids == match_ids, which is the info we need here
+    match_id: Annotated[str, Query(
+        description="The match ID from which the selection was generated."
+    )] = None,
+    user: kb_auth.KBaseUser = Depends(_AUTH),
 ) -> CreatedSet:
-    # TODO ERRORS assemblyset description is in autometadata, which means it can't be more than
-    #             ~850 bytes. What do?
     desc = setinfo.description if setinfo else None
     appstate = app_state.get_app_state(r)
+    match_ = None
+    if match_id:
+        match_ = await processing_matches.get_match(appstate, match_id, user, verbose=True)
     upa, type_ = await processing_selections.save_set_to_workspace(
         appstate,
         selection_id,
@@ -437,6 +447,7 @@ async def create_sets(
         ws_type,
         service_ver=VERSION,
         description=desc,
+        match_=match_, 
     )
     return CreatedSet(set=WorkspaceSet(upa=upa, type=type_))
 


### PR DESCRIPTION
Match details are added to the set provenance

Still do to: add default parameters to the user submitted parameters when saving the match. Currently default parameters are excluded