### PR TITLE
RE2022-263, RE2022-271: set default file group

### DIFF
--- a/docs/data_pipeline_procedure.md
+++ b/docs/data_pipeline_procedure.md
@@ -4,11 +4,12 @@
    * Set working directory and its subdirectories to the default group
       ```commandline
       file_group=kbase
-      find /global/cfs/cdirs/kbase/collections/working_dir -type d -exec chgrp $file_group {} \;
+      working_dir=dir_to_set_group
+      find /global/cfs/cdirs/kbase/collections/$working_dir -type d -exec chgrp $file_group {} \;
       ```
    * set the "setgid" bit so that anything created or modified in that direcotry will automatically be set to the default group
       ```commandline
-      find /global/cfs/cdirs/kbase/collections/working_dir -type d -exec chmod g+s {} \;
+      find /global/cfs/cdirs/kbase/collections/$working_dir -type d -exec chmod g+s {} \;
       ```
 
 ## Download Source Data

--- a/docs/data_pipeline_procedure.md
+++ b/docs/data_pipeline_procedure.md
@@ -1,5 +1,16 @@
 # Data Pipeline Procedure
 
+## Set working directory to default group
+   * Set working directory and its subdirectories to the default group
+      ```commandline
+      file_group=kbase
+      find /global/cfs/cdirs/kbase/collections/working_dir -type d -exec chgrp $file_group {} \;
+      ```
+   * set the "setgid" bit so that anything created or modified in that direcotry will automatically be set to the default group
+      ```commandline
+      find /global/cfs/cdirs/kbase/collections/working_dir -type d -exec chmod g+s {} \;
+      ```
+
 ## Download Source Data
    * Workspace Downloader
      * Example usage


### PR DESCRIPTION
after running those two comments on /global/cfs/cdirs/kbase/collections, tested rerun tools and parsers, all newly generated files are on kbase group now. 