### PR TITLE
RE2022-275: reconstruct heatmap row cells

### DIFF
--- a/src/loaders/common/loader_helper.py
+++ b/src/loaders/common/loader_helper.py
@@ -496,7 +496,7 @@ class ExplicitDefaultsHelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
         return super()._get_help_string(action)
 
 
-def transform_heatmap_row_cells(data: dict):
+def transform_heatmap_row_cells(data: dict[str, Any]):
     """
     Transform the cells structure in a heatmap row to a new structure.
 

--- a/src/loaders/common/loader_helper.py
+++ b/src/loaders/common/loader_helper.py
@@ -22,6 +22,12 @@ from src.common.product_models.columnar_attribs_common_models import (
     AttributesColumn,
     ColumnarAttributesMeta,
 )
+from src.common.product_models.heatmap_common_models import (
+    FIELD_HEATMAP_ROW_CELLS,
+    FIELD_HEATMAP_COL_ID,
+    FIELD_HEATMAP_CELL_ID,
+    FIELD_HEATMAP_CELL_VALUE,
+)
 from src.common.storage.db_doc_conversions import (
     collection_data_id_key,
     collection_load_version_key,
@@ -45,6 +51,9 @@ This module contains helper functions used for loaders (e.g. compute_genome_attr
 """
 
 NONE_STR = ['N/A', 'NA', 'None', 'none', 'null', 'Null', 'NULL', '']
+
+HEATMAP_COL_PREFIX = "col"
+HEATMAP_COL_SEPARATOR = '_'
 
 
 def _convert_to_iso8601(date_string: str) -> str:
@@ -485,3 +494,46 @@ class ExplicitDefaultsHelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
         if action.default is None or action.default is False:
             return action.help
         return super()._get_help_string(action)
+
+
+def transform_heatmap_row_cells(data: dict):
+    """
+    Transform the cells structure in a heatmap row to a new structure.
+
+    The new structure is a set of keys and values where the keys are constructed from the old structure.
+
+    The old structure:
+    "cells": [
+        {
+            "cell_id": "cell_0",
+            "col_id": "0",
+            "val": 0.0
+        },
+        {
+            "cell_id": "cell_1",
+            "col_id": "1",
+            "val": 1.0
+        }
+    ]
+
+    The new structure:
+    "col_0_cell_id": "cell_0",
+    "col_0_val": 0.0,
+    "col_1_cell_id": "cell_1",
+    "col_1_val": 1.0
+
+    """
+
+    # Iterate over the 'cells' structure and remove them from the data structure while constructing the new structure
+    for cell in data.pop(FIELD_HEATMAP_ROW_CELLS):
+        col_id = cell.get(FIELD_HEATMAP_COL_ID)
+
+        # Construct keys and values for the new structure
+        cell_id_key = f"{HEATMAP_COL_PREFIX}{HEATMAP_COL_SEPARATOR}{col_id}{HEATMAP_COL_SEPARATOR}{FIELD_HEATMAP_CELL_ID}"
+        cell_val_key = f"{HEATMAP_COL_PREFIX}{HEATMAP_COL_SEPARATOR}{col_id}{HEATMAP_COL_SEPARATOR}{FIELD_HEATMAP_CELL_VALUE}"
+
+        # Add the new keys and values to the data structure
+        data[cell_id_key] = cell.get(FIELD_HEATMAP_CELL_ID)
+        data[cell_val_key] = cell.get(FIELD_HEATMAP_CELL_VALUE)
+
+

--- a/src/loaders/common/loader_helper.py
+++ b/src/loaders/common/loader_helper.py
@@ -498,7 +498,7 @@ class ExplicitDefaultsHelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
 
 def transform_heatmap_row_cells(data: dict[str, Any]):
     """
-    Transform the cells structure in a heatmap row to a new structure.
+    Transform, in place, the cells structure in a heatmap row to a new structure.
 
     The new structure is a set of keys and values where the keys are constructed from the old structure.
     new structured key format: <HEATMAP_COL_PREFIX>_<col_id>_<FIELD_HEATMAP_CELL_ID|FIELD_HEATMAP_CELL_VALUEl>

--- a/src/loaders/common/loader_helper.py
+++ b/src/loaders/common/loader_helper.py
@@ -501,6 +501,9 @@ def transform_heatmap_row_cells(data: dict):
     Transform the cells structure in a heatmap row to a new structure.
 
     The new structure is a set of keys and values where the keys are constructed from the old structure.
+    new structured key format: <HEATMAP_COL_PREFIX>_<col_id>_<FIELD_HEATMAP_CELL_ID|FIELD_HEATMAP_CELL_VALUEl>
+
+    e.g.
 
     The old structure:
     "cells": [

--- a/src/loaders/genome_collection/parse_PMI_biolog_data.py
+++ b/src/loaders/genome_collection/parse_PMI_biolog_data.py
@@ -35,7 +35,11 @@ from src.common.storage.collection_and_field_names import (
 from src.common.storage.db_doc_conversions import collection_load_version_key, collection_data_id_key
 from src.common.storage.field_names import FLD_KBASE_ID
 from src.loaders.common import loader_common_names
-from src.loaders.common.loader_helper import init_row_doc, create_import_files
+from src.loaders.common.loader_helper import (
+    init_row_doc,
+    create_import_files,
+    transform_heatmap_row_cells
+)
 from src.loaders.genome_collection.parse_tool_results import HEATMAP_FILE_ROOT
 
 GROWTH_MEDIA_COL_NAME = 'growth_media'
@@ -242,11 +246,14 @@ def generate_pmi_biolog_heatmap_data(
                 FLD_ARANGO_KEY: collection_data_id_key(kbase_collection, load_ver, cell_uuid),
             })
 
+        row_data = {FLD_KBASE_ID: assembly_ref,
+                    FLD_KB_DISPLAY_NAME: assembly_name,
+                    FIELD_HEATMAP_ROW_CELLS: cells,
+                    FIELD_HEATMAP_ROW_META: {'growth_media': row[GROWTH_MEDIA_COL_NAME], }}
+        transform_heatmap_row_cells(row_data)
+
         # append a document for the heatmap rows
-        heatmap_rows.append(dict({FLD_KBASE_ID: assembly_ref,
-                                  FLD_KB_DISPLAY_NAME: assembly_name,
-                                  FIELD_HEATMAP_ROW_CELLS: cells,
-                                  FIELD_HEATMAP_ROW_META: {'growth_media': row[GROWTH_MEDIA_COL_NAME], }},
+        heatmap_rows.append(dict(row_data,
                                  **init_row_doc(kbase_collection, load_ver, assembly_ref)))
 
     heatmap_meta_dict[FIELD_HEATMAP_MIN_VALUE] = min_value

--- a/src/loaders/genome_collection/parse_tool_results.py
+++ b/src/loaders/genome_collection/parse_tool_results.py
@@ -78,6 +78,7 @@ from src.loaders.common.loader_helper import (
     merge_docs,
     create_import_dir,
     process_columnar_meta,
+    transform_heatmap_row_cells,
 )
 from src.loaders.compute_tools.tool_common import run_command
 from src.loaders.compute_tools.tool_result_parser import (
@@ -513,6 +514,8 @@ def microtrait(root_dir, env, kbase_collection, load_ver, fatal_ids):
                         cell_val = cell[FIELD_HEATMAP_CELL_VALUE]
                         min_value = min(min_value, cell_val)
                         max_value = max(max_value, cell_val)
+
+                    transform_heatmap_row_cells(data)
 
                     meta_info = _read_metadata_file(meta_lookup[data_id])
                     data[names.FLD_KB_DISPLAY_NAME] = meta_info.get(loader_common_names.FLD_KB_OBJ_NAME)

--- a/src/loaders/genome_collection/parse_tool_results.py
+++ b/src/loaders/genome_collection/parse_tool_results.py
@@ -515,6 +515,8 @@ def microtrait(root_dir, env, kbase_collection, load_ver, fatal_ids):
                         min_value = min(min_value, cell_val)
                         max_value = max(max_value, cell_val)
 
+                    # transform heatmap row cells structure due to Arango nested search is not supported in the
+                    # Community Edition
                     transform_heatmap_row_cells(data)
 
                     meta_info = _read_metadata_file(meta_lookup[data_id])


### PR DESCRIPTION
transformed heatmap_data looks like:

{"kbase_id": "69037_10_1", "col_1_cell_id": "efe9dc0c-39c8-48d2-88ea-4fd93de5ec0c", "col_1_val": 0, "col_2_cell_id": "f5145e84-d370-4b1d-9906-edc58d4725ef", "col_2_val": 3, "col_3_cell_id": "a5fb45d9-e42e-44e6-821e-a418fb11e33d", "col_3_val": 0, "col_4_cell_id": "a2f1c72f-7515-4c77-83d9-4cd7b7e04256", "col_4_val": 0, "col_5_cell_id": "4677ebb4-328a-493d-9baa-370f60d9afa3", "col_5_val": 0, "col_6_cell_id": "b7b84f0a-55d3-4b65-a0ec-9ddb0fa138f6", "col_6_val": 0, "col_7_cell_id": "bd0f5d06-1322-44f9-b222-6524075ab095", "col_7_val": 2, ... ...