### PR TITLE
RE2022-294: relax gtdb version matching

### DIFF
--- a/src/service/matchers/lineage_matcher.py
+++ b/src/service/matchers/lineage_matcher.py
@@ -28,7 +28,7 @@ _COLLECTION_PARAMS_GTDB_VERSIONS_KEY = "gtdb_versions"
 class GTDBLineageMatcherCollectionParameters(BaseModel):
     "Parameters for the GTDB lineage matcher."
     gtdb_versions: list[str] = Field(
-        example=["214.0", "214.0"],
+        example=["214.0", "214.1"],
         description="The allowed GTDB versions of the collection in which the matcher is installed. " +
             "Input data to the matcher must match one of the allowed versions of GTDB or the match will " +
             "abort.",

--- a/src/service/matchers/lineage_matcher.py
+++ b/src/service/matchers/lineage_matcher.py
@@ -4,9 +4,9 @@ Matches assemblies and genomes to collections based on the GTDB lineage string.
 
 import logging
 import re
-from typing import Any, Self
+from typing import Any, Self, Set
 
-from pydantic import ConfigDict, BaseModel, Field, model_validator
+from pydantic import ConfigDict, BaseModel, Field, model_validator, constr
 
 from src.common.constants import GTDB_UNCLASSIFIED_PREFIX
 from src.common.gtdb_lineage import GTDBRank, GTDBLineage, GTDBLineageError
@@ -27,21 +27,13 @@ _COLLECTION_PARAMS_GTDB_VERSIONS_KEY = "gtdb_versions"
 
 class GTDBLineageMatcherCollectionParameters(BaseModel):
     "Parameters for the GTDB lineage matcher."
-    gtdb_versions: list[str] = Field(
-        example=["214.0", "214.1"],
+    gtdb_versions: Set[constr(pattern=r"^\d{2,4}\.\d{1,2}$")] = Field(
+        example={"214.0", "214.1"},
         description="The allowed GTDB versions of the collection in which the matcher is installed. " +
             "Input data to the matcher must match one of the allowed versions of GTDB or the match will " +
             "abort.",
     )
     model_config = ConfigDict(extra="forbid")
-
-    @model_validator(mode="after")
-    def _check_gtdb_versions(self) -> Self:
-        pattern = r"^\d{2,4}\.\d{1,2}$"  # giving a little room for expansion
-        for version in self.gtdb_versions:
-            if not re.match(pattern, version):
-                raise ValueError(f"Invalid version format: {version}")
-        return self
 
 
 class GTDBLineageMatcherUserParameters(BaseModel):

--- a/src/service/matchers/lineage_matcher.py
+++ b/src/service/matchers/lineage_matcher.py
@@ -3,10 +3,9 @@ Matches assemblies and genomes to collections based on the GTDB lineage string.
 """
 
 import logging
-import re
-from typing import Any, Self
+from typing import Any
 
-from pydantic import ConfigDict, BaseModel, Field, model_validator, conlist, constr
+from pydantic import ConfigDict, BaseModel, Field, conlist, constr
 
 from src.common.constants import GTDB_UNCLASSIFIED_PREFIX
 from src.common.gtdb_lineage import GTDBRank, GTDBLineage, GTDBLineageError

--- a/src/service/matchers/lineage_matcher.py
+++ b/src/service/matchers/lineage_matcher.py
@@ -6,7 +6,7 @@ import logging
 import re
 from typing import Any, Self
 
-from pydantic import ConfigDict, BaseModel, Field, model_validator, conlist
+from pydantic import ConfigDict, BaseModel, Field, model_validator, conlist, constr
 
 from src.common.constants import GTDB_UNCLASSIFIED_PREFIX
 from src.common.gtdb_lineage import GTDBRank, GTDBLineage, GTDBLineageError
@@ -23,25 +23,17 @@ _GTDB_LINEAGE_METADATA_KEY = "GTDB_lineage"
 _GTDB_LINEAGE_VERSION_METADATA_KEY = "GTDB_source_ver"
 
 _COLLECTION_PARAMS_GTDB_VERSIONS_KEY = "gtdb_versions"
-
+_GTDB_VER_PATTERN = r"^\d{2,4}\.\d{1,2}$"  # giving a little room for expansion
 
 class GTDBLineageMatcherCollectionParameters(BaseModel):
     "Parameters for the GTDB lineage matcher."
-    gtdb_versions: conlist(str, min_length=1) = Field(
+    gtdb_versions: conlist(constr(pattern=_GTDB_VER_PATTERN), min_length=1) = Field(
         example=["214.0", "214.1"],
         description="The allowed GTDB versions of the collection in which the matcher is installed. " +
             "Input data to the matcher must match one of the allowed versions of GTDB or the match will " +
             "abort.",
     )
     model_config = ConfigDict(extra="forbid")
-
-    @model_validator(mode="after")
-    def _check_gtdb_versions(self) -> Self:
-        pattern = r"^\d{2,4}\.\d{1,2}$"  # giving a little room for expansion
-        for version in self.gtdb_versions:
-            if not re.match(pattern, version):
-                raise ValueError(f"Invalid version format: {version}")
-        return self
 
 
 class GTDBLineageMatcherUserParameters(BaseModel):

--- a/src/service/models.py
+++ b/src/service/models.py
@@ -87,7 +87,7 @@ V is the version. The version may not be omitted. Reference paths
 )
 FIELD_USER_PARAMETERS_EXAMPLE = {"gtdb_rank": "species"}
 FIELD_USER_PARAMETERS_DESCRIPTION = "The user parameters for the match."
-FIELD_MATCHER_PARAMETERS_EXAMPLE = {'gtdb_version': '207.0'}
+FIELD_MATCHER_PARAMETERS_EXAMPLE = {'gtdb_versions': ['214.0', '214.1']}
 FIELD_MATCHER_PARAMETERS_DESCRIPTION = ("Any collection (as opposed to user provided) parameters "
     + "for the matcher. What these are will depend on the matcher in question")
 FIELD_SELECTION_EXAMPLE = ["GB_GCA_000006155.2", "GB_GCA_000007385.1"]

--- a/src/service/models.py
+++ b/src/service/models.py
@@ -87,7 +87,7 @@ V is the version. The version may not be omitted. Reference paths
 )
 FIELD_USER_PARAMETERS_EXAMPLE = {"gtdb_rank": "species"}
 FIELD_USER_PARAMETERS_DESCRIPTION = "The user parameters for the match."
-FIELD_MATCHER_PARAMETERS_EXAMPLE = {'gtdb_versions': ['214.0', '214.1']}
+FIELD_MATCHER_PARAMETERS_EXAMPLE = {'gtdb_versions': {'214.0', '214.1'}}
 FIELD_MATCHER_PARAMETERS_DESCRIPTION = ("Any collection (as opposed to user provided) parameters "
     + "for the matcher. What these are will depend on the matcher in question")
 FIELD_SELECTION_EXAMPLE = ["GB_GCA_000006155.2", "GB_GCA_000007385.1"]

--- a/src/service/models.py
+++ b/src/service/models.py
@@ -87,7 +87,7 @@ V is the version. The version may not be omitted. Reference paths
 )
 FIELD_USER_PARAMETERS_EXAMPLE = {"gtdb_rank": "species"}
 FIELD_USER_PARAMETERS_DESCRIPTION = "The user parameters for the match."
-FIELD_MATCHER_PARAMETERS_EXAMPLE = {'gtdb_versions': {'214.0', '214.1'}}
+FIELD_MATCHER_PARAMETERS_EXAMPLE = {'gtdb_versions': ['214.0', '214.1']}
 FIELD_MATCHER_PARAMETERS_DESCRIPTION = ("Any collection (as opposed to user provided) parameters "
     + "for the matcher. What these are will depend on the matcher in question")
 FIELD_SELECTION_EXAMPLE = ["GB_GCA_000006155.2", "GB_GCA_000007385.1"]


### PR DESCRIPTION
comparing to fuzzy matching approach, we need to re-active all collections if we do it this way. 