### PR TITLE
RE2022-320: add sample meta endpont

### DIFF
--- a/src/common/product_models/columnar_attribs_common_models.py
+++ b/src/common/product_models/columnar_attribs_common_models.py
@@ -13,6 +13,7 @@ from typing import Annotated, Self
 
 
 FIELD_COLUMNS = "columns"
+NON_VISIBLE = "non_visible"
 
 
 class ColumnType(str, Enum):
@@ -49,9 +50,9 @@ class FilterStrategy(str, Enum):
     """ A search based on ngram matching. """
 
 
-class AttributesColumnSpec(BaseModel):
+class AttributesColumnBase(BaseModel):
     """
-    A specification for a column in an attributes table.
+    A base class for a specification for a column in an attributes table.
     """
     key: str = Field(
         example="checkm_completeness",
@@ -66,11 +67,7 @@ class AttributesColumnSpec(BaseModel):
         description="The filter strategy for the column if any. Not all column types need "
             + "a filter strategy."
     )] = None
-    non_visible: Annotated[bool, Field(
-        example=False,
-        description="Whether the column is visible to the user. "
-             + "If True, the display name and category fields are not required"
-    )] = False
+
     display_name: Annotated[str | None, Field(
         example="Completeness",
         description="The display name of the column. "
@@ -95,6 +92,17 @@ class AttributesColumnSpec(BaseModel):
             raise ValueError("Only string types may have a filter strategy")
         return self
 
+
+class AttributesColumnSpec(AttributesColumnBase):
+    """
+    A specification for a column in an attributes table.
+    """
+    non_visible: Annotated[bool, Field(
+        example=False,
+        description="Whether the column is visible to the user. "
+             + "If True, the display name and category fields are not required"
+    )] = False
+
     @model_validator(mode="after")
     def _check_visible_col(self) -> Self:
         if not self.non_visible:
@@ -115,7 +123,7 @@ class ColumnarAttributesSpec(BaseModel):
     )] = list()
 
 
-class AttributesColumn(AttributesColumnSpec):
+class AttributesColumn(AttributesColumnBase):
     min_value: Annotated[int | float | str | None, Field(
         example="2023-08-25T22:08:30.576+0000",
         description="The minimum value for the column for numeric and date columns. "

--- a/src/service/data_products/common_functions.py
+++ b/src/service/data_products/common_functions.py
@@ -141,8 +141,8 @@ async def get_columnar_attribs_meta(
     )
 
     doc[col_models.FIELD_COLUMNS] = [
-        col_models.AttributesColumn(**d) for d in doc[col_models.FIELD_COLUMNS] if
-        not return_only_visible or not d[col_models.NON_VISIBLE]
+        col_models.AttributesColumn(**d) for d in doc[col_models.FIELD_COLUMNS]
+        if not return_only_visible or not d[col_models.NON_VISIBLE]
     ]
 
     return col_models.ColumnarAttributesMeta(**remove_collection_keys(doc))

--- a/src/service/data_products/common_functions.py
+++ b/src/service/data_products/common_functions.py
@@ -161,7 +161,7 @@ async def get_product_meta(
     Get the columnar attributes meta document for a collection used by /meta endpoint.
 
     r - the request.
-    collection - the arango collection containing the document.
+    collection - the arango collection containing the meta information.
     collection_id - the ID of the Collection for which to retrieve the meta information.
     data_product - the ID of the data product from which to retrieve the load version.
     load_ver_override - an override for the load version. If provided:

--- a/src/service/data_products/common_functions.py
+++ b/src/service/data_products/common_functions.py
@@ -167,7 +167,7 @@ async def get_product_meta(
     load_ver_override - an override for the load version. If provided:
         * the user must be a service administrator
         * the collection is not checked for the existence of the data product.
-    user - the user. Ignored if load_ver is not provided; must be a service administrator.
+    user - the user. Ignored if load_ver_override is not provided; must be a service administrator.
 
     """
 

--- a/src/service/data_products/common_functions.py
+++ b/src/service/data_products/common_functions.py
@@ -164,47 +164,7 @@ async def get_product_meta(
     user - the user. Ignored if load_ver is not provided; must be a service administrator.
 
     """
-    storage = app_state.get_app_state(r).arangostorage
-    _, load_ver = await get_load_version(storage, collection_id, data_product, load_ver_override, user)
 
-    doc = await get_collection_singleton_from_db(
-            storage,
-            collection,
-            collection_id,
-            load_ver,
-            bool(load_ver_override)
-    )
-    doc[col_models.FIELD_COLUMNS] = [col_models.AttributesColumn(**d)
-                                     for d in doc[col_models.FIELD_COLUMNS]]
-
-    meta = col_models.ColumnarAttributesMeta(**remove_collection_keys(doc))
-    meta.columns = [c for c in meta.columns if not c.non_visible]
-
-    return meta
-
-
-async def get_table_meta(
-        r: Request,
-        collection: str,
-        collection_id: str,
-        data_product: str,
-        load_ver_override,
-        user: kb_auth.KBaseUser,
-
-) -> col_models.ColumnarAttributesMeta:
-    """
-    Get the columnar attributes meta document for a collection used by /meta endpoint.
-
-    r - the request.
-    collection - the arango collection containing the document.
-    collection_id - the ID of the Collection from which to retrieve the load version and possibly
-        collection object.
-    data_product - the ID of the data product from which to retrieve the load version.
-    load_ver_override - an override for the load version. If provided:
-        * the user must be a service administrator
-        * the collection is not checked for the existence of the data product.
-    user - the user. Ignored if load_ver is not provided; must be a service administrator.
-    """
     storage = app_state.get_app_state(r).arangostorage
     _, load_ver = await get_load_version(storage, collection_id, data_product, load_ver_override, user)
     meta = await get_columnar_attribs_meta(storage, collection, collection_id, load_ver, bool(load_ver_override))

--- a/src/service/data_products/common_functions.py
+++ b/src/service/data_products/common_functions.py
@@ -137,7 +137,7 @@ async def get_columnar_attribs_meta(
             collection,
             collection_id,
             load_ver,
-            bool(load_ver_override)
+            load_ver_override
     )
 
     doc[col_models.FIELD_COLUMNS] = [

--- a/src/service/data_products/common_functions.py
+++ b/src/service/data_products/common_functions.py
@@ -153,7 +153,7 @@ async def get_product_meta(
         collection: str,
         collection_id: str,
         data_product: str,
-        load_ver_override,
+        load_ver_override: str,
         user: kb_auth.KBaseUser,
 
 ) -> col_models.ColumnarAttributesMeta:

--- a/src/service/data_products/common_functions.py
+++ b/src/service/data_products/common_functions.py
@@ -162,8 +162,7 @@ async def get_product_meta(
 
     r - the request.
     collection - the arango collection containing the document.
-    collection_id - the ID of the Collection from which to retrieve the load version and possibly
-        collection object.
+    collection_id - the ID of the Collection for which to retrieve the meta information.
     data_product - the ID of the data product from which to retrieve the load version.
     load_ver_override - an override for the load version. If provided:
         * the user must be a service administrator

--- a/src/service/data_products/common_functions.py
+++ b/src/service/data_products/common_functions.py
@@ -113,18 +113,45 @@ async def get_collection_singleton_from_db(
 
 
 async def get_columnar_attribs_meta(
+        storage: ArangoStorage,
+        collection: str,
+        collection_id: str,
+        load_ver: str,
+        load_ver_override: bool
+) -> col_models.ColumnarAttributesMeta:
+    """
+    Get the columnar attributes meta document for a collection. The document is expected to be
+    a singleton per collection load version.
+
+    storage - the storage system.
+    collection - the arango collection containing the document.
+    collection_id - the KBase collection containing the document.
+    load_ver - the load version of the collection.
+    load_ver_override - whether to override the load version.
+    """
+    doc = await get_collection_singleton_from_db(
+            storage,
+            collection,
+            collection_id,
+            load_ver,
+            bool(load_ver_override)
+    )
+    doc[col_models.FIELD_COLUMNS] = [col_models.AttributesColumn(**d)
+                                     for d in doc[col_models.FIELD_COLUMNS]]
+    return col_models.ColumnarAttributesMeta(**remove_collection_keys(doc))
+
+
+async def get_product_meta(
         r: Request,
         collection: str,
         collection_id: str,
         data_product: str,
         load_ver_override,
         user: kb_auth.KBaseUser,
-        return_only_visible: bool = False
 
 ) -> col_models.ColumnarAttributesMeta:
     """
-    Get the columnar attributes meta document for a collection. The document is expected to be
-    a singleton per collection load version.
+    Get the columnar attributes meta document for a collection used by /meta endpoint.
 
     r - the request.
     collection - the arango collection containing the document.
@@ -135,7 +162,6 @@ async def get_columnar_attribs_meta(
         * the user must be a service administrator
         * the collection is not checked for the existence of the data product.
     user - the user. Ignored if load_ver is not provided; must be a service administrator.
-    return_only_visible - whether to return only visible columns. Default false.
 
     """
     storage = app_state.get_app_state(r).arangostorage
@@ -152,8 +178,37 @@ async def get_columnar_attribs_meta(
                                      for d in doc[col_models.FIELD_COLUMNS]]
 
     meta = col_models.ColumnarAttributesMeta(**remove_collection_keys(doc))
-    if return_only_visible:
-        meta.columns = [c for c in meta.columns if not c.non_visible]
+    meta.columns = [c for c in meta.columns if not c.non_visible]
+
+    return meta
+
+
+async def get_table_meta(
+        r: Request,
+        collection: str,
+        collection_id: str,
+        data_product: str,
+        load_ver_override,
+        user: kb_auth.KBaseUser,
+
+) -> col_models.ColumnarAttributesMeta:
+    """
+    Get the columnar attributes meta document for a collection used by /meta endpoint.
+
+    r - the request.
+    collection - the arango collection containing the document.
+    collection_id - the ID of the Collection from which to retrieve the load version and possibly
+        collection object.
+    data_product - the ID of the data product from which to retrieve the load version.
+    load_ver_override - an override for the load version. If provided:
+        * the user must be a service administrator
+        * the collection is not checked for the existence of the data product.
+    user - the user. Ignored if load_ver is not provided; must be a service administrator.
+    """
+    storage = app_state.get_app_state(r).arangostorage
+    _, load_ver = await get_load_version(storage, collection_id, data_product, load_ver_override, user)
+    meta = await get_columnar_attribs_meta(storage, collection, collection_id, load_ver, bool(load_ver_override))
+    meta.columns = [c for c in meta.columns if not c.non_visible]
 
     return meta
 

--- a/src/service/data_products/genome_attributes.py
+++ b/src/service/data_products/genome_attributes.py
@@ -266,7 +266,7 @@ async def get_genome_attributes_meta(
     storage = app_state.get_app_state(r).arangostorage
     _, load_ver = await get_load_version(storage, collection_id, ID, load_ver_override, user)
     meta = await get_columnar_attribs_meta(
-        storage, names.COLL_GENOME_ATTRIBS_META, collection_id, load_ver, load_ver_override)
+        storage, names.COLL_GENOME_ATTRIBS_META, collection_id, load_ver, bool(load_ver_override))
     meta.columns = [c for c in meta.columns if not c.non_visible]
     return meta
 

--- a/src/service/data_products/genome_attributes.py
+++ b/src/service/data_products/genome_attributes.py
@@ -262,12 +262,15 @@ async def get_genome_attributes_meta(
     collection_id: str = PATH_VALIDATOR_COLLECTION_ID,
     load_ver_override: common_models.QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE = None,
     user: kb_auth.KBaseUser = Depends(_OPT_AUTH)
-    ) -> col_models.ColumnarAttributesMeta:
-    storage = app_state.get_app_state(r).arangostorage
-    _, load_ver = await get_load_version(storage, collection_id, ID, load_ver_override, user)
-    meta = await get_columnar_attribs_meta(
-        storage, names.COLL_GENOME_ATTRIBS_META, collection_id, load_ver, bool(load_ver_override))
-    meta.columns = [c for c in meta.columns if not c.non_visible]
+) -> col_models.ColumnarAttributesMeta:
+    meta = await get_columnar_attribs_meta(r,
+                                           names.COLL_GENOME_ATTRIBS_META,
+                                           collection_id,
+                                           ID,
+                                           load_ver_override,
+                                           user,
+                                           return_only_visible=True)
+    # TODO: remote non_visible field from meta
     return meta
 
 
@@ -321,11 +324,12 @@ async def get_genome_attributes(
         load_ver_override,
         ID,
         (await get_columnar_attribs_meta(
-            appstate.arangostorage,
+            r,
             names.COLL_GENOME_ATTRIBS_META,
             collection_id,
-            load_ver,
-            load_ver_override)).columns,
+            ID,
+            load_ver_override,
+            user)).columns,
         view_name=coll.get_data_product(ID).search_view if coll else None,
         count=count,
         sort_on=sort_on,
@@ -404,11 +408,12 @@ async def get_histogram(
         load_ver_override,
         ID,
         (await get_columnar_attribs_meta(
-            appstate.arangostorage,
+            r,
             names.COLL_GENOME_ATTRIBS_META,
             collection_id,
-            load_ver,
-            load_ver_override)).columns,
+            ID,
+            load_ver_override,
+            user)).columns,
         view_name=coll.get_data_product(ID).search_view if coll else None,
         filter_conjunction=conjunction,
         match_spec=match_spec,
@@ -491,11 +496,12 @@ async def get_xy_scatter(
         load_ver_override,
         ID,
         (await get_columnar_attribs_meta(
-            appstate.arangostorage,
+            r,
             names.COLL_GENOME_ATTRIBS_META,
             collection_id,
-            load_ver,
-            load_ver_override)).columns,
+            ID,
+            load_ver_override,
+            user)).columns,
         view_name=coll.get_data_product(ID).search_view if coll else None,
         filter_conjunction=conjunction,
         match_spec=match_spec,

--- a/src/service/data_products/genome_attributes.py
+++ b/src/service/data_products/genome_attributes.py
@@ -263,15 +263,15 @@ async def get_genome_attributes_meta(
     load_ver_override: common_models.QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE = None,
     user: kb_auth.KBaseUser = Depends(_OPT_AUTH)
 ) -> col_models.ColumnarAttributesMeta:
-    meta = await get_columnar_attribs_meta(r,
+
+    return await get_columnar_attribs_meta(r,
                                            names.COLL_GENOME_ATTRIBS_META,
                                            collection_id,
                                            ID,
                                            load_ver_override,
                                            user,
                                            return_only_visible=True)
-    # TODO: remote non_visible field from meta
-    return meta
+
 
 
 @_ROUTER.get(

--- a/src/service/data_products/genome_attributes.py
+++ b/src/service/data_products/genome_attributes.py
@@ -273,7 +273,6 @@ async def get_genome_attributes_meta(
                                            return_only_visible=True)
 
 
-
 @_ROUTER.get(
     "/",
     response_model=TableAttributes,

--- a/src/service/data_products/genome_attributes.py
+++ b/src/service/data_products/genome_attributes.py
@@ -2,25 +2,25 @@
 The genome_attribs data product, which provides genome attributes for a collection.
 """
 
-from collections import defaultdict
 import logging
+from collections import defaultdict
 from typing import Any, Callable, Annotated
 
+import numpy as np
 from fastapi import APIRouter, Request, Depends, Query
 from pydantic import BaseModel
 from pydantic import Field
 
-import numpy as np
-
 import src.common.storage.collection_and_field_names as names
 from src.common.product_models import columnar_attribs_common_models as col_models
 from src.service import app_state
-from src.service.app_state_data_structures import CollectionsState, PickleableDependencies
 from src.service import errors
 from src.service import kb_auth
-from src.service import processing_matches
 from src.service import models
+from src.service import processing_matches
 from src.service import processing_selections
+from src.service.app_state_data_structures import CollectionsState, PickleableDependencies
+from src.service.data_products import common_models
 from src.service.data_products.common_functions import (
     get_load_version,
     remove_collection_keys,
@@ -29,9 +29,8 @@ from src.service.data_products.common_functions import (
     override_load_version,
     query_table,
     query_simple_collection_list,
-    get_collection_singleton_from_db,
+    get_columnar_attribs_meta,
 )
-from src.service.data_products import common_models
 from src.service.data_products.data_product_processing import (
     MATCH_ID_PREFIX,
     SELECTION_ID_PREFIX,
@@ -266,25 +265,10 @@ async def get_genome_attributes_meta(
     ) -> col_models.ColumnarAttributesMeta:
     storage = app_state.get_app_state(r).arangostorage
     _, load_ver = await get_load_version(storage, collection_id, ID, load_ver_override, user)
-    meta = await _get_genome_attributes_meta_internal(
-        storage, collection_id, load_ver, load_ver_override)
+    meta = await get_columnar_attribs_meta(
+        storage, names.COLL_GENOME_ATTRIBS_META, collection_id, load_ver, load_ver_override)
     meta.columns = [c for c in meta.columns if not c.non_visible]
     return meta
-
-
-async def _get_genome_attributes_meta_internal(
-    storage: ArangoStorage, collection_id: str, load_ver: str, load_ver_override: bool
-) -> col_models.ColumnarAttributesMeta:
-    doc = await get_collection_singleton_from_db(
-            storage,
-            names.COLL_GENOME_ATTRIBS_META,
-            collection_id,
-            load_ver,
-            bool(load_ver_override)
-    )
-    doc[col_models.FIELD_COLUMNS] = [col_models.AttributesColumn(**d)
-                                     for d in doc[col_models.FIELD_COLUMNS]]
-    return col_models.ColumnarAttributesMeta(**remove_collection_keys(doc))
 
 
 @_ROUTER.get(
@@ -336,8 +320,12 @@ async def get_genome_attributes(
         load_ver,
         load_ver_override,
         ID,
-        (await _get_genome_attributes_meta_internal(
-            appstate.arangostorage, collection_id, load_ver, load_ver_override)).columns,
+        (await get_columnar_attribs_meta(
+            appstate.arangostorage,
+            names.COLL_GENOME_ATTRIBS_META,
+            collection_id,
+            load_ver,
+            load_ver_override)).columns,
         view_name=coll.get_data_product(ID).search_view if coll else None,
         count=count,
         sort_on=sort_on,
@@ -415,8 +403,12 @@ async def get_histogram(
         load_ver,
         load_ver_override,
         ID,
-        (await _get_genome_attributes_meta_internal(
-            appstate.arangostorage, collection_id, load_ver, load_ver_override)).columns,
+        (await get_columnar_attribs_meta(
+            appstate.arangostorage,
+            names.COLL_GENOME_ATTRIBS_META,
+            collection_id,
+            load_ver,
+            load_ver_override)).columns,
         view_name=coll.get_data_product(ID).search_view if coll else None,
         filter_conjunction=conjunction,
         match_spec=match_spec,
@@ -498,8 +490,12 @@ async def get_xy_scatter(
         load_ver,
         load_ver_override,
         ID,
-        (await _get_genome_attributes_meta_internal(
-            appstate.arangostorage, collection_id, load_ver, load_ver_override)).columns,
+        (await get_columnar_attribs_meta(
+            appstate.arangostorage,
+            names.COLL_GENOME_ATTRIBS_META,
+            collection_id,
+            load_ver,
+            load_ver_override)).columns,
         view_name=coll.get_data_product(ID).search_view if coll else None,
         filter_conjunction=conjunction,
         match_spec=match_spec,

--- a/src/service/data_products/samples.py
+++ b/src/service/data_products/samples.py
@@ -180,10 +180,16 @@ async def get_samples_meta(
     load_ver_override: common_models.QUERY_VALIDATOR_LOAD_VERSION_OVERRIDE = None,
     user: kb_auth.KBaseUser = Depends(_OPT_AUTH)
 ) -> col_models.ColumnarAttributesMeta:
-    storage = app_state.get_app_state(r).arangostorage
-    _, load_ver = await get_load_version(storage, collection_id, ID, load_ver_override, user)
-    meta = await get_columnar_attribs_meta(storage, names.COLL_SAMPLES_META, collection_id, load_ver, bool(load_ver_override))
-    meta.columns = [c for c in meta.columns if not c.non_visible]
+
+    meta = await get_columnar_attribs_meta(r,
+                                           names.COLL_SAMPLES_META,
+                                           collection_id,
+                                           ID,
+                                           load_ver_override,
+                                           user,
+                                           return_only_visible=True)
+    # TODO: remote non_visible field from meta
+
     return meta
 
 

--- a/src/service/data_products/samples.py
+++ b/src/service/data_products/samples.py
@@ -17,7 +17,7 @@ from src.service.data_products.common_functions import (
     query_table,
     get_load_version,
     QueryTableResult,
-    get_columnar_attribs_meta
+    get_columnar_attribs_meta, get_product_meta
 )
 from src.service.data_products.data_product_processing import (
     MATCH_ID_PREFIX,
@@ -181,18 +181,17 @@ async def get_samples_meta(
     user: kb_auth.KBaseUser = Depends(_OPT_AUTH)
 ) -> col_models.ColumnarAttributesMeta:
 
-    return await get_columnar_attribs_meta(r,
-                                           names.COLL_SAMPLES_META,
-                                           collection_id,
-                                           ID,
-                                           load_ver_override,
-                                           user,
-                                           return_only_visible=True)
+    return await get_product_meta(r,
+                                  names.COLL_SAMPLES_META,
+                                  collection_id,
+                                  ID,
+                                  load_ver_override,
+                                  user)
 
 
 # At some point we're going to want to filter/sort on fields. We may want a list of fields
 # somewhere to check input fields are ok... but really we could just fetch the first document
-# in the collection and check the fields 
+# in the collection and check the fields
 @_ROUTER.get(
     "/",
     response_model=SamplesTable,

--- a/src/service/data_products/samples.py
+++ b/src/service/data_products/samples.py
@@ -182,7 +182,7 @@ async def get_samples_meta(
 ) -> col_models.ColumnarAttributesMeta:
     storage = app_state.get_app_state(r).arangostorage
     _, load_ver = await get_load_version(storage, collection_id, ID, load_ver_override, user)
-    meta = await get_columnar_attribs_meta(storage, names.COLL_SAMPLES_META, collection_id, load_ver, load_ver_override)
+    meta = await get_columnar_attribs_meta(storage, names.COLL_SAMPLES_META, collection_id, load_ver, bool(load_ver_override))
     meta.columns = [c for c in meta.columns if not c.non_visible]
     return meta
 

--- a/src/service/data_products/samples.py
+++ b/src/service/data_products/samples.py
@@ -17,7 +17,7 @@ from src.service.data_products.common_functions import (
     query_table,
     get_load_version,
     QueryTableResult,
-    get_columnar_attribs_meta, get_product_meta
+    get_product_meta
 )
 from src.service.data_products.data_product_processing import (
     MATCH_ID_PREFIX,

--- a/src/service/data_products/samples.py
+++ b/src/service/data_products/samples.py
@@ -181,16 +181,13 @@ async def get_samples_meta(
     user: kb_auth.KBaseUser = Depends(_OPT_AUTH)
 ) -> col_models.ColumnarAttributesMeta:
 
-    meta = await get_columnar_attribs_meta(r,
+    return await get_columnar_attribs_meta(r,
                                            names.COLL_SAMPLES_META,
                                            collection_id,
                                            ID,
                                            load_ver_override,
                                            user,
                                            return_only_visible=True)
-    # TODO: remote non_visible field from meta
-
-    return meta
 
 
 # At some point we're going to want to filter/sort on fields. We may want a list of fields


### PR DESCRIPTION
example local curl of the new endpoint.

```
(dev) tgu@collections (dev_sample_filtering)$curl -X 'GET' \
  'http://127.0.0.1:5000/collections/ENIGMA/data_products/samples/meta' \
  -H 'accept: application/json' | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3174  100  3174    0     0   393k      0 --:--:-- --:--:-- --:--:--  774k
{
    "columns": [
        {
            "key": "kbase_display_name",
            "type": "string",
            "filter_strategy": "ngram",
            "non_visible": false,
            "display_name": "KBase Name",
            "category": "Identifiers",
            "description": null,
            "min_value": null,
            "max_value": null,
            "enum_values": null
        },
        {
            "key": "longitude",
            "type": "float",
            "filter_strategy": null,
            "non_visible": false,
            "display_name": "Longitude",
            "category": "Geolocation",
            "description": "Longitude of the location where the sample was collected in WGS 84 coordinate system.",
            "min_value": -84.33630514999999,
            "max_value": -84.27208199999997,
            "enum_values": null
        },
        {
            "key": "enigma:date",
            "type": "date",
            "filter_strategy": null,
            "non_visible": false,
            "display_name": "Date",
            "category": "Collection",
            "description": "Date (YYYY-MM-DD)",
            "min_value": "2012-07-25",
            "max_value": "2020-10-20",
            "enum_values": null
        },
        {
            "key": "enigma:well_name",
            "type": "string",
            "filter_strategy": "ngram",
            "non_visible": false,
            "display_name": "Well Name",
            "category": "Description",
            "description": "Well Name (ID)",
            "min_value": null,
            "max_value": null,
            "enum_values": null
        },
        {
            "key": "material",
            "type": "string",
            "filter_strategy": "identity",
            "non_visible": false,
            "display_name": "Material",
            "category": "Description",
            "description": "Material from ENVO (child of ENVO:00010483)",
            "min_value": null,
            "max_value": null,
            "enum_values": null
        },
        {
            "key": "sample_template",
            "type": "string",
            "filter_strategy": "identity",
            "non_visible": false,
            "display_name": "Template",
            "category": "Description",
            "description": "Template Format",
            "min_value": null,
            "max_value": null,
            "enum_values": null
        },
        {
            "key": "kbase_sample_id",
            "type": "string",
            "filter_strategy": "identity",
            "non_visible": false,
            "display_name": "KBase Sample ID",
            "category": "Identifiers",
            "description": null,
            "min_value": null,
            "max_value": null,
            "enum_values": null
        },
        {
            "key": "enigma:time_zone",
            "type": "string",
            "filter_strategy": "identity",
            "non_visible": false,
            "display_name": "Time Zone",
            "category": "Collection",
            "description": "Time Zone (relative to UTC)",
            "min_value": null,
            "max_value": null,
            "enum_values": null
        },
        {
            "key": "genome_count",
            "type": "int",
            "filter_strategy": null,
            "non_visible": false,
            "display_name": "Genome Count",
            "category": "Statistics",
            "description": null,
            "min_value": 1,
            "max_value": 63,
            "enum_values": null
        },
        {
            "key": "enigma:collection_time",
            "type": "string",
            "filter_strategy": "identity",
            "non_visible": false,
            "display_name": "Collection Time",
            "category": "Collection",
            "description": "Collection Time",
            "min_value": null,
            "max_value": null,
            "enum_values": null
        },
        {
            "key": "env_package",
            "type": "string",
            "filter_strategy": "identity",
            "non_visible": false,
            "display_name": "Environmental Package",
            "category": "Description",
            "description": "Environmental Package (MIxS vocabulary)",
            "min_value": null,
            "max_value": null,
            "enum_values": null
        },
        {
            "key": "latitude",
            "type": "float",
            "filter_strategy": null,
            "non_visible": false,
            "display_name": "Latitude",
            "category": "Geolocation",
            "description": "Latitude of the location where the sample was collected in WGS 84 coordinate system.",
            "min_value": 35.94087687,
            "max_value": 35.978858,
            "enum_values": null
        },
        {
            "key": "enigma:experiment_name",
            "type": "string",
            "filter_strategy": "ngram",
            "non_visible": false,
            "display_name": "Experiment Name",
            "category": "Description",
            "description": "Experiment Name",
            "min_value": null,
            "max_value": null,
            "enum_values": null
        }
    ],
    "count": 36
}
```