### PR TITLE
RE2022-320: add update samples filter set to enable filtering

### DIFF
--- a/src/service/data_products/data_product_processing.py
+++ b/src/service/data_products/data_product_processing.py
@@ -43,7 +43,7 @@ async def get_load_version_and_processes( # pretty huge method sig here
     match_id: str | None = None,
     selection_id: str | None = None,
     multiple_ids: bool = False,
-) -> tuple[str, models.DataProductProcess, models.DataProductProcess]:
+) -> tuple[str, models.DataProductProcess, models.DataProductProcess, models.ActiveCollection | None]:
     f"""
     Get the appropriate load version to use when querying data along with match and / or selection
     processes, if match and selection IDs are provided.
@@ -93,7 +93,7 @@ async def get_load_version_and_processes( # pretty huge method sig here
             appstate, coll, selection_id, data_product,
             partial(_process_subset, collection, multiple_ids)
         )
-    return load_ver, dp_match, dp_sel
+    return load_ver, dp_match, dp_sel, coll
 
 
 async def _process_subset(
@@ -154,7 +154,7 @@ async def get_missing_ids(
     if not match_id and not selection_id:
         raise errors.IllegalParameterError(
             "At last one of a match ID or selection ID must be supplied")
-    _, dp_match, dp_sel = await get_load_version_and_processes(
+    _, dp_match, dp_sel, _ = await get_load_version_and_processes(
         appstate,
         user,
         collection,

--- a/src/service/data_products/heatmap.py
+++ b/src/service/data_products/heatmap.py
@@ -345,7 +345,7 @@ GET <host>/collections/PMI/data_products/{self._id}/?filter_kbase_id=69278_1006_
         # For some reason returning the data as a model slows down the endpoint by ~10x.
         # Serializing manually and returning a plain response is much faster
         appstate = app_state.get_app_state(r)
-        load_ver, dp_match, dp_sel = await get_load_version_and_processes(
+        load_ver, dp_match, dp_sel, _ = await get_load_version_and_processes(
             appstate,
             user,
             self._colname_data,

--- a/src/service/data_products/samples.py
+++ b/src/service/data_products/samples.py
@@ -241,7 +241,7 @@ async def get_samples(
     # we have a max limit of 1000, which means sorting is O(n log2 1000).
     # Otherwise we need indexes for every sort
     appstate = app_state.get_app_state(r)
-    load_ver, dp_match, dp_sel = await get_load_version_and_processes(
+    load_ver, dp_match, dp_sel, coll = await get_load_version_and_processes(
         appstate,
         user,
         names.COLL_SAMPLES,
@@ -254,7 +254,7 @@ async def get_samples(
     )
     if status_only:
         return _response(dp_match=dp_match, dp_sel=dp_sel)
-    coll = await appstate.arangostorage.get_collection_active(collection_id)
+
     filters = await get_filters(
         r,
         names.COLL_SAMPLES,
@@ -352,7 +352,7 @@ async def get_sample_locations(
     # might need to return a bare Response if the pydantic checking gets too expensive
     # might need some sort of pagination
     appstate = app_state.get_app_state(r)
-    load_ver, dp_match, dp_sel = await get_load_version_and_processes(
+    load_ver, dp_match, dp_sel, _ = await get_load_version_and_processes(
         appstate,
         user,
         names.COLL_SAMPLES,


### PR DESCRIPTION
example local endpoint call:

```
(dev) tgu@collections (dev_sample_filtering)$curl -X 'GET' \
  'http://127.0.0.1:5000/collections/ENIGMA/data_products/samples/?output_table=false&limit=1&filter_genome_count=%5B3,4%5D' \
  -H 'accept: application/json' \
  -H "Authorization: Bearer $token" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   487  100   487    0     0   1407      0 --:--:-- --:--:-- --:--:--  1419
{
    "match_state": null,
    "selection_state": null,
    "skip": 0,
    "limit": 1,
    "fields": null,
    "table": null,
    "data": [
        {
            "enigma:date": "2014-06-17",
            "enigma:experiment_name": "Groundwater",
            "enigma:time_zone": "UTC\u221204:00",
            "enigma:well_name": "DP16D",
            "env_package": "water",
            "genome_count": 3,
            "kbase_display_name": "DP16D-06-17-14",
            "kbase_sample_id": "11dd1e1e-c721-460b-9cc3-a517784fcdb8",
            "latitude": 35.97550000000001,
            "longitude": -84.27467799999998,
            "material": "ENVO:01001004",
            "sample_template": "ENIGMA"
        }
    ],
    "count": null
}
```