### PR TITLE
RE2022-327: add default sort taxa count

### DIFF
--- a/src/service/data_products/taxa_count.py
+++ b/src/service/data_products/taxa_count.py
@@ -226,6 +226,7 @@ async def get_taxa_counts(
             + "Note that if a selection ID is set, any load version override is ignored."),
     sort_priority: str = Query(
         default=None,
+        example="standard",  # or make a constant for this. That's probably better
         description=f"A comma separated list of sort priorities. Valid values are: "
                     f"{', '.join(_SORT_PRIORITY_ORDER_MAP.keys())}. ",
     ),

--- a/src/service/data_products/taxa_count.py
+++ b/src/service/data_products/taxa_count.py
@@ -265,7 +265,7 @@ def _fill_missing_orders(sort_order: list[str]):
     if not isinstance(sort_order, list):
         raise ValueError(f"sort_order must be a list of strings, provided: {sort_order}")
 
-    return sort_order + [order for order in _DEFAULT_SORT_ORDER if order not in sort_order]
+    return [order for order in _DEFAULT_SORT_ORDER if order not in sort_order] + sort_order
 
 
 def _sort_taxa_counts(

--- a/src/service/data_products/taxa_count.py
+++ b/src/service/data_products/taxa_count.py
@@ -261,17 +261,6 @@ async def get_taxa_counts(
     return _taxa_counts(dp_match=dp_match, dp_sel=dp_sel, data=q)
 
 
-def _sort_dict_list(
-        dict_list: list[dict],
-        key: str):
-    # Sort taxa count records, a list of dicts, in place by the key of dictionary with None values last.
-    # Key values should be either integer or None.
-    # Certain keys, such as 'sel_count' or 'match_count,' may not exist in all dictionaries.
-    # For instance, these keys might be absent if the corresponding match or selection process did not occur/complete.
-    # In such cases, the default value of float('-inf') is used to ensure that the dictionaries are sorted correctly.
-    dict_list.sort(key=lambda x: x.get(key, _INF_NEG), reverse=True)
-
-
 def _fill_missing_orders(sort_order: list[str]):
     # fill in missing orders with the default sort order
     if not isinstance(sort_order, list):
@@ -306,7 +295,7 @@ def _sort_taxa_counts(
         sort_order = [names.FLD_TAXA_COUNT_COUNT]
 
     for k in sort_order:
-        _sort_dict_list(q, k)
+        q.sort(key=lambda x: x[k], reverse=True)
 
 
 def _taxa_counts(

--- a/src/service/data_products/taxa_count.py
+++ b/src/service/data_products/taxa_count.py
@@ -269,14 +269,10 @@ def _fill_missing_orders(sort_order: list[str]):
 
 
 def _sort_taxa_counts(
-        q: list[dict],
+        q: list[dict[str, Any]],
         sort_order: list[str] = None):
     # sort the taxa counts result in place by the sort order
     sort_order = _fill_missing_orders(sort_order) if sort_order else _DEFAULT_SORT_ORDER
-
-    # Remove the `count` order if it is the first element since the records are already sorted by count in the
-    # _query function.
-    sort_order.pop(0) if sort_order[0] == names.FLD_TAXA_COUNT_COUNT else None
 
     for k in sort_order:
         if k not in _DEFAULT_SORT_ORDER:

--- a/src/service/data_products/taxa_count.py
+++ b/src/service/data_products/taxa_count.py
@@ -53,6 +53,8 @@ _DEFAULT_SORT_ORDER = [names.FLD_TAXA_COUNT_COUNT,
                        _FLD_TAXA_COUNT_MATCH_COUNT,
                        _FLD_TAXA_COUNT_SEL_COUNT]
 
+_INF_NEG = float('-inf')
+
 
 class TaxaCountSpec(DataProductSpec):
 
@@ -250,14 +252,13 @@ async def get_taxa_counts(
 
 def _sort_dict_list(
         dict_list: list[dict],
-        key: str,
-        reverse: bool = True):
+        key: str):
     # Sort taxa count records, a list of dicts, in place by the key of dictionary with None values last.
     # Key values should be either numeric or None.
     # Certain keys, such as 'sel_count' or 'match_count,' may not exist in all dictionaries.
     # For instance, these keys might be absent if the corresponding match or selection process did not occur/complete.
     # In such cases, the default value of float('-inf') is used to ensure that the dictionaries are sorted correctly.
-    dict_list.sort(key=lambda x: (int(x.get(key)) if x.get(key) is not None else float('-inf')), reverse=reverse)
+    dict_list.sort(key=lambda x: (int(x.get(key)) if x.get(key) is not None else _INF_NEG), reverse=True)
 
 
 def _fill_missing_orders(sort_order: list[str]):

--- a/src/service/data_products/taxa_count.py
+++ b/src/service/data_products/taxa_count.py
@@ -48,14 +48,10 @@ _MAX_COUNT = 20  # max number of taxa count records to return
 _FLD_TAXA_COUNT_MATCH_COUNT = "match_count"
 _FLD_TAXA_COUNT_SEL_COUNT = "sel_count"
 
-# The default sorting order for taxa counts results
-_DEFAULT_SORT_ORDER = [names.FLD_TAXA_COUNT_COUNT,
-                       _FLD_TAXA_COUNT_MATCH_COUNT,
-                       _FLD_TAXA_COUNT_SEL_COUNT]
-
 _INF_NEG = float('-inf')
 
 # The mapping of sort priority to the corresponding field in the taxa count records
+# NOTE that the order of the fields in the mapping is the default precedence order for sorting
 _SORT_PRIORITY_ORDER_MAP = {
     "selected": _FLD_TAXA_COUNT_SEL_COUNT,
     "matched": _FLD_TAXA_COUNT_MATCH_COUNT,
@@ -267,7 +263,7 @@ def _fill_missing_orders(sort_order: list[str], processed_count: list[str]):
     if not isinstance(sort_order, list):
         raise ValueError(f"sort_order must be a list of strings, provided: {sort_order}")
 
-    missing_orders = [order for order in _DEFAULT_SORT_ORDER
+    missing_orders = [order for order in list(_SORT_PRIORITY_ORDER_MAP.values())[::-1]
                       if order not in sort_order and
                       (order in processed_count or order == names.FLD_TAXA_COUNT_COUNT)]
 

--- a/src/service/data_products/taxa_count.py
+++ b/src/service/data_products/taxa_count.py
@@ -262,7 +262,7 @@ def _sort_dict_list(
 
 def _fill_missing_orders(sort_order: list[str]):
     # fill in missing orders with the default sort order
-    if isinstance(sort_order, list):
+    if not isinstance(sort_order, list):
         raise ValueError(f"sort_order must be a list of strings, provided: {sort_order}")
 
     return sort_order + [order for order in _DEFAULT_SORT_ORDER if order not in sort_order]

--- a/src/service/data_products/taxa_count.py
+++ b/src/service/data_products/taxa_count.py
@@ -298,8 +298,8 @@ def _sort_taxa_counts(
     missing_processes = [p for p in sort_order_rev if p not in processed_count and p != names.FLD_TAXA_COUNT_COUNT]
     if missing_processes:
         missing_priority = [key for key, value in _SORT_PRIORITY_ORDER_MAP.items() if value in missing_processes]
-        raise errors.IllegalParameterError(f"No occurrences of the {missing_priority} data were found in the "
-                                           f"taxa count records")
+        raise errors.IllegalParameterError(f"Specified sort priority {missing_priority} without providing associated "
+                                           f"match or selection identifier")
 
     # fill in missing orders with the default precedence order
     sort_order = _fill_missing_orders(sort_order_rev[::-1], processed_count)


### PR DESCRIPTION
example local endpoint return:

default sort:
```
(dev) tgu@collections (dev_taxa_count_ordering)$curl -X 'GET' \
  "$server_url/collections/PMI/data_products/taxa_count/counts/$rank/?match_id=$match_id&status_only=false" \
  -H 'accept: application/json' \
  -H "Authorization: Bearer $token" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   333  100   333    0     0  26232      0 --:--:-- --:--:-- --:--:-- 33300
{
    "match_state": "complete",
    "selection_state": null,
    "data": [
        {
            "name": "Actinomycetota",
            "count": 82,
            "match_count": 82,
            "sel_count": null
        },
        {
            "name": "Pseudomonadota",
            "count": 367,
            "match_count": 0,
            "sel_count": null
        },
        {
            "name": "Bacteroidota",
            "count": 53,
            "match_count": 0,
            "sel_count": null
        },
        {
            "name": "Bacillota",
            "count": 48,
            "match_count": 0,
            "sel_count": null
        }
    ]
}
```

specify sort order:
```
(dev) tgu@collections (dev_taxa_count_ordering)$sort_priority=standard%2C%20matched
(dev) tgu@collections (dev_taxa_count_ordering)$curl -X 'GET' \
  "$server_url/collections/PMI/data_products/taxa_count/counts/$rank/?match_id=$match_id&status_only=false&sort_priority=$sort_priority" \
  -H 'accept: application/json' \
  -H "Authorization: Bearer $token" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   333  100   333    0     0  25848      0 --:--:-- --:--:-- --:--:-- 33300
{
    "match_state": "complete",
    "selection_state": null,
    "data": [
        {
            "name": "Pseudomonadota",
            "count": 367,
            "match_count": 0,
            "sel_count": null
        },
        {
            "name": "Actinomycetota",
            "count": 82,
            "match_count": 82,
            "sel_count": null
        },
        {
            "name": "Bacteroidota",
            "count": 53,
            "match_count": 0,
            "sel_count": null
        },
        {
            "name": "Bacillota",
            "count": 48,
            "match_count": 0,
            "sel_count": null
        }
    ]
}
```