### PR TITLE
RE2022-328: update uploaded.yaml file struct

### DIFF
--- a/src/loaders/workspace_uploader/workspace_uploader.py
+++ b/src/loaders/workspace_uploader/workspace_uploader.py
@@ -274,8 +274,8 @@ def _read_upload_status_yaml_file(
             <load_id>:
                 assembly_upa: <assembly_upa>
                 assembly_filename: <assembly_filename>
-                genome_upa: <genome_upa>
-                genome_filename: <genome_filename>
+                genome_upa: <genome_upa> (can be None)
+                genome_filename: <genome_filename> (can be None)
     """
 
     if upload_env_key not in loader_common_names.KB_ENV:

--- a/src/loaders/workspace_uploader/workspace_uploader.py
+++ b/src/loaders/workspace_uploader/workspace_uploader.py
@@ -264,6 +264,7 @@ def _read_upload_status_yaml_file(
     workspace_id: int,
     load_id: str,
     obj_dir: str,
+    create_assembly_only: bool = True,
 ) -> tuple[dict[str, dict[int, list[str]]], bool]:
     """
     Get metadata and upload status of a WS object from the uploaded.yaml file.
@@ -290,8 +291,11 @@ def _read_upload_status_yaml_file(
 
     workspace_dict = data.setdefault(upload_env_key, {}).setdefault(workspace_id, {})
 
-    # TODO - we might want to check that upa and filename matches
     uploaded = load_id in workspace_dict
+
+    # In the event of genome upload and an assembly with the identical load_id has already been uploaded.
+    if not create_assembly_only:
+        uploaded = uploaded and workspace_dict[load_id].get(_KEY_GENOME_UPA)
 
     return data, uploaded
 

--- a/test/src/loaders/workspace_uploader/workspace_uploader_test.py
+++ b/test/src/loaders/workspace_uploader/workspace_uploader_test.py
@@ -85,11 +85,12 @@ def test_read_upload_status_yaml_file(setup_and_teardown):
 
     # test empty yaml file in assembly_dir
     data, uploaded = workspace_uploader._read_upload_status_yaml_file(
-        "CI", 12345, "214", assembly_dir, assembly_name
+        "CI", 12345, "214", assembly_dir
     )
+
     expected_data = {
-        "CI": {12345: {assembly_name: {"loads": {}}}}
-    }
+        "CI": {12345: {}}}
+
     assert not uploaded
     assert expected_data == data
 
@@ -106,12 +107,14 @@ def test_update_upload_status_yaml_file(setup_and_teardown):
         "CI", 12345, "214", "12345_58_1", assembly_tuple
     )
     data, uploaded = workspace_uploader._read_upload_status_yaml_file(
-        "CI", 12345, "214", assembly_dir, assembly_name
+        "CI", 12345, "214", assembly_dir,
     )
 
     expected_data = {
-        "CI": {12345: {assembly_name: {"loads": {"214": {"upa": "12345_58_1"}}}}}
-    }
+        "CI": {12345: {"214": {"assembly_upa": "12345_58_1",
+                               "assembly_filename": assembly_name,
+                               "genome_upa": None,
+                               "genome_filename": None}}}}
 
     assert uploaded
     assert expected_data == data
@@ -216,11 +219,13 @@ def test_post_process(setup_and_teardown):
     )
 
     data, uploaded = workspace_uploader._read_upload_status_yaml_file(
-        "CI", 88888, "214", host_assembly_dir, assembly_name
+        "CI", 88888, "214", host_assembly_dir
     )
     expected_data = {
-        "CI": {88888: {assembly_name: {"loads": {"214": {"upa": "12345_58_1"}}}}}
-    }
+        "CI": {88888: {"214": {"assembly_upa": "12345_58_1",
+                               "assembly_filename": assembly_name,
+                               "genome_upa": None,
+                               "genome_filename": None}}}}
 
     dest_file = os.path.join(
         os.path.join(output_dir, "12345_58_1"), f"12345_58_1.fna.gz"

--- a/test/src/loaders/workspace_uploader/workspace_uploader_test.py
+++ b/test/src/loaders/workspace_uploader/workspace_uploader_test.py
@@ -88,7 +88,7 @@ def test_read_upload_status_yaml_file(setup_and_teardown):
         "CI", 12345, "214", assembly_dir, assembly_name
     )
     expected_data = {
-        "CI": {12345: {"file_name": assembly_name, "loads": {}}}
+        "CI": {12345: {assembly_name: {workspace_uploader._KEY_LOADS: {}}}}
     }
     assert not uploaded
     assert expected_data == data
@@ -110,7 +110,8 @@ def test_update_upload_status_yaml_file(setup_and_teardown):
     )
 
     expected_data = {
-        "CI": {12345: {"file_name": assembly_name, "loads": {"214": {"upa": "12345_58_1"}}}}
+        "CI": {12345: {assembly_name: {workspace_uploader._KEY_LOADS:
+                                           {"214": {workspace_uploader._KEY_UPA: "12345_58_1"}}}}}
     }
 
     assert uploaded
@@ -219,7 +220,8 @@ def test_post_process(setup_and_teardown):
         "CI", 88888, "214", host_assembly_dir, assembly_name
     )
     expected_data = {
-        "CI": {88888: {"file_name": assembly_name, "loads": {"214": {"upa": "12345_58_1"}}}}
+        "CI": {88888: {assembly_name: {workspace_uploader._KEY_LOADS:
+                                           {"214": {workspace_uploader._KEY_UPA: "12345_58_1"}}}}}
     }
 
     dest_file = os.path.join(

--- a/test/src/loaders/workspace_uploader/workspace_uploader_test.py
+++ b/test/src/loaders/workspace_uploader/workspace_uploader_test.py
@@ -88,7 +88,7 @@ def test_read_upload_status_yaml_file(setup_and_teardown):
         "CI", 12345, "214", assembly_dir, assembly_name
     )
     expected_data = {
-        "CI": {12345: {assembly_name: {workspace_uploader._KEY_LOADS: {}}}}
+        "CI": {12345: {assembly_name: {"loads": {}}}}
     }
     assert not uploaded
     assert expected_data == data
@@ -110,8 +110,7 @@ def test_update_upload_status_yaml_file(setup_and_teardown):
     )
 
     expected_data = {
-        "CI": {12345: {assembly_name: {workspace_uploader._KEY_LOADS:
-                                           {"214": {workspace_uploader._KEY_UPA: "12345_58_1"}}}}}
+        "CI": {12345: {assembly_name: {"loads": {"214": {"upa": "12345_58_1"}}}}}
     }
 
     assert uploaded
@@ -220,8 +219,7 @@ def test_post_process(setup_and_teardown):
         "CI", 88888, "214", host_assembly_dir, assembly_name
     )
     expected_data = {
-        "CI": {88888: {assembly_name: {workspace_uploader._KEY_LOADS:
-                                           {"214": {workspace_uploader._KEY_UPA: "12345_58_1"}}}}}
+        "CI": {88888: {assembly_name: {"loads": {"214": {"upa": "12345_58_1"}}}}}
     }
 
     dest_file = os.path.join(


### PR DESCRIPTION
An overwrite for the 'file_name' will happen when uploading multiple files using the previous structure.