### PR TITLE
add no_cast to _mtchsel

### DIFF
--- a/src/common/collection_column_specs/genome_attribs-GTDB.yml
+++ b/src/common/collection_column_specs/genome_attribs-GTDB.yml
@@ -13,6 +13,7 @@ columns:
      type: string
      filter_strategy: identity
      non_visible: true
+     no_cast: true
 
    - key: kbase_id
      type: string

--- a/src/common/collection_column_specs/genome_attribs-PMI.yml
+++ b/src/common/collection_column_specs/genome_attribs-PMI.yml
@@ -13,6 +13,7 @@ columns:
      type: string
      filter_strategy: identity
      non_visible: true
+     no_cast: true
 
    - key: kbase_id
      type: string

--- a/src/common/collection_column_specs/samples-ENIGMA.yml
+++ b/src/common/collection_column_specs/samples-ENIGMA.yml
@@ -19,10 +19,10 @@ columns:
     type: string
     filter_strategy: identity
     non_visible: true
+    no_cast: true
     display_name: Related KBase IDs
     category: Identifiers
     description:
-    no_cast: true
 
   - key: genome_count
     type: int

--- a/src/common/collection_column_specs/samples-ENIGMA.yml
+++ b/src/common/collection_column_specs/samples-ENIGMA.yml
@@ -13,6 +13,7 @@ columns:
     type: string
     filter_strategy: identity
     non_visible: true
+    no_cast: true
 
   - key: kbase_ids
     type: string

--- a/src/common/collection_column_specs/samples-ENIGMA.yml
+++ b/src/common/collection_column_specs/samples-ENIGMA.yml
@@ -22,6 +22,7 @@ columns:
     display_name: Related KBase IDs
     category: Identifiers
     description:
+    no_cast: true
 
   - key: genome_count
     type: int

--- a/src/common/collection_column_specs/samples-GROW.yml
+++ b/src/common/collection_column_specs/samples-GROW.yml
@@ -19,10 +19,10 @@ columns:
     type: string
     filter_strategy: identity
     non_visible: true
+    no_cast: true
     display_name: Related KBase IDs
     category: Identifiers
     description:
-    no_cast: true
 
   - key: genome_count
     type: int

--- a/src/common/collection_column_specs/samples-GROW.yml
+++ b/src/common/collection_column_specs/samples-GROW.yml
@@ -13,6 +13,7 @@ columns:
     type: string
     filter_strategy: identity
     non_visible: true
+    no_cast: true
 
   - key: kbase_ids
     type: string

--- a/src/common/collection_column_specs/samples-GROW.yml
+++ b/src/common/collection_column_specs/samples-GROW.yml
@@ -22,6 +22,7 @@ columns:
     display_name: Related KBase IDs
     category: Identifiers
     description:
+    no_cast: true
 
   - key: genome_count
     type: int

--- a/src/common/product_models/columnar_attribs_common_models.py
+++ b/src/common/product_models/columnar_attribs_common_models.py
@@ -103,6 +103,12 @@ class AttributesColumnSpec(AttributesColumnBase):
              + "If True, the display name and category fields are not required"
     )] = False
 
+    no_cast: Annotated[bool, Field(
+        example=False,
+        description="Whether the column value should not be cast to the specified type according to "
+            + "the column type. If True, the column value will not be cast to the specified type."
+    )] = False
+
     @model_validator(mode="after")
     def _check_visible_col(self) -> Self:
         if not self.non_visible:

--- a/src/loaders/common/loader_helper.py
+++ b/src/loaders/common/loader_helper.py
@@ -115,21 +115,20 @@ def process_columnar_meta(
     spec = load_spec(product_id, kbase_collection)
     columns = list()
     for col_spec in spec.columns:
-        key, col_type, no_cast = col_spec.key, col_spec.type, col_spec.no_cast
         values = _convert_values_to_type(docs,
-                                         key,
-                                         col_type,
+                                         col_spec.key,
+                                         col_spec.type,
                                          ignore_missing=ignore_missing,
-                                         no_cast=no_cast)
+                                         no_cast=col_spec.no_cast)
         min_value, max_value, enum_values = None, None, None
-        if col_type in [ColumnType.INT, ColumnType.FLOAT, ColumnType.DATE]:
+        if col_spec.type in [ColumnType.INT, ColumnType.FLOAT, ColumnType.DATE]:
             if values:
                 min_value, max_value = min(values), max(values)
             else:
                 # set min_value and max_value to None if all values from the column are None
                 min_value = max_value = None
 
-        elif col_type == ColumnType.ENUM:
+        elif col_spec.type == ColumnType.ENUM:
             enum_values = list(set(values))
             enum_values.sort()
 

--- a/test/src/common/collection_column_specs/load_specs_test.py
+++ b/test/src/common/collection_column_specs/load_specs_test.py
@@ -68,7 +68,7 @@ def test_all_specs_load_merge():
     assert key2spec["translation_table"] == AttributesColumnSpec(
         key="translation_table", type=it, display_name="Translation Table", category="Other",)
     assert key2spec["_mtchsel"] == AttributesColumnSpec(
-        key="_mtchsel", type=st, filter_strategy=ident, non_visible=True)
+        key="_mtchsel", type=st, filter_strategy=ident, non_visible=True, no_cast=True)
 
 
 def test_load_single_spec_from_toolchain():


### PR DESCRIPTION
example generated genome_attrbs.jsonl  file.

```
{"kbase_id": "69037_2_1", "Contamination": 0.85, "Completeness": 88.28, "_key": "6c95a1d46e809f84063dccf93700ffa9", "coll": "GROW", "load_ver": "tian_test_taskfarmer", "_mtchsel": [], "user_genome": "69037_2_1_kbase", "classification": "d__Bacteria;p__Verrucomicrobiota;c__Verrucomicrobiae;o__Chthoniobacterales;f__Chthoniobacteraceae;g__Chth-196;s__", "fastani_reference": null, "fastani_reference_radius": null, "fastani_taxonomy": null, "fastani_ani": null, "fastani_af": null, "closest_placement_reference": "GCA_945883955.1", "closest_placement_radius": 95.0, "closest_placement_taxonomy": "d__Bacteria;p__Verrucomicrobiota;c__Verrucomicrobiae;o__Chthoniobacterales;f__Chthoniobacteraceae;g__Chth-196;s__Chth-196 sp945883955", "closest_placement_ani": 76.9, "closest_placement_af": 0.093, "pplacer_taxonomy": "d__Bacteria;p__Verrucomicrobiota;c__Verrucomicrobiae;o__Chthoniobacterales;f__Chthoniobacteraceae;g__Chth-196;s__", "classification_method": "taxonomic classification defined by topology and ANI", "note": "classification based on placement in class-level tree", "other_related_references(genome_id,species_name,radius,ANI,AF)": "GCA_945874745.1, s__Chth-196 sp945874745, 95.0, 76.48, 0.079; GCA_903916085.1, s__Chth-196 sp903916085, 95.0, 76.36, 0.047; GCA_003402745.1, s__Chth-196 sp003402745, 95.0, 76.19, 0.062; GCA_945906945.1, s__Chth-196 sp945906945, 95.0, 75.8, 0.052; GCA_903919125.1, s__Chth-196 sp903919125, 95.0, 75.58, 0.036", "msa_percent": 81.85, "translation_table": 11, "red_value": "0.93961", "warnings": null, "kbase_display_name": "altamaha_2019_sw_WHONDRS-S19S_0010_A_bin_34_mag_assembly", "_upas": {"KBaseGenomeAnnotations.Assembly": "69037/2/1", "KBaseGenomes.Genome": "69037/3/1"}, "kbase_genome_size": 3670106, "kbase_gc_content": 0.5997, "kbase_num_contigs": 233, "kbase_num_cds": 3053, "kbase_num_protein_encoding_genes": 3053, "kbase_sample_id": "79db2b9e-0581-4a53-9154-5aa6030aed02"}
```