### PR TITLE
Safe filter fields in AQL

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # KBase Collections Release Notes
 
+## 0.1.2
+
+* Fixed a bug that caused requests with filters to fail for filter keys containing colons.
+* Adds eggNOG mappper as an experimental tool in the pipeline. It currently does not integrate
+  into the collections pipeline proper.
+
 ## 0.1.1
 
 * Fixed a bug in the service manager script that would cause it to fail if the service had never

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,7 @@
 ## 0.1.2
 
 * Fixed a bug that caused requests with filters to fail for filter keys containing colons.
-* Adds eggNOG mappper as an experimental tool in the pipeline. It currently does not integrate
+* Adds eggNOG mapper as an experimental tool in the pipeline. It currently does not integrate
   into the collections pipeline proper.
 
 ## 0.1.1

--- a/src/common/version.py
+++ b/src/common/version.py
@@ -2,4 +2,4 @@
 The version of the KBase collections software.
 '''
 
-VERSION = "0.1.1"
+VERSION = "0.1.2"

--- a/src/service/filtering/filters.py
+++ b/src/service/filtering/filters.py
@@ -69,7 +69,7 @@ class AbstractFilter(ABC):
         Convert the filter to lines of ArangoSearch AQL and bind variables.
         
         identifier - the identifier for where the search is to take place, for example
-            `doc.classification`. This will be inserted verbatim into the search constraint, e.g.
+            `doc["classification"]`. This will be inserted verbatim into the search constraint, e.g.
             `f"{identifer} > 47`
         var_prefix - a prefix to apply to variable names, including bind variables,
             to prevent collisions between multiple filters.
@@ -145,7 +145,7 @@ class BooleanFilter(AbstractFilter):
         Convert the filter to lines of ArangoSearch AQL and bind variables.
 
         identifier - the identifier for where the search is to take place, for example
-            `doc.classification`. This will be inserted verbatim into the search constraint, e.g.
+            `doc["classification"]`. This will be inserted verbatim into the search constraint, e.g.
             `f"{identifer} == true`
         var_prefix - a prefix to apply to variable names, including bind variables,
             to prevent collisions between multiple filters.
@@ -291,7 +291,7 @@ class RangeFilter(AbstractFilter):
         Convert the filter to lines of ArangoSearch AQL and bind variables.
         
         identifier - the identifier for where the search is to take place, for example
-            `doc.classification`. This will be inserted verbatim into the search constraint, e.g.
+            `doc["classification"]`. This will be inserted verbatim into the search constraint, e.g.
             `f"{identifer} > 47`
         var_prefix - a prefix to apply to variable names, including bind variables,
             to prevent collisions between multiple filters.
@@ -374,7 +374,7 @@ class StringFilter(AbstractFilter):
         Convert the filter to lines of ArangoSearch AQL and bind variables.
         
         identifier - the identifier for where the search is to take place, for example
-            `doc.classification`. This will be inserted verbatim into the search constraint, e.g.
+            `doc["classification"]. This will be inserted verbatim into the search constraint, e.g.
             `f"{identifer} > 47`
         var_prefix - a prefix to apply to variable names, including bind variables,
             to prevent collisions between multiple filters.
@@ -548,7 +548,7 @@ class FilterSet:
             "load_ver": self.load_ver,
         }
         for i, (field, filter_) in enumerate(self._filters.items(), start=1):
-            search_part = filter_.to_arangosearch_aql(f"{self.doc_var}.{field}", f"v{i}_")
+            search_part = filter_.to_arangosearch_aql(f"{self.doc_var}[\"{field}\"]", f"v{i}_")
             if search_part.variable_assignments:
                 for var, expression in search_part.variable_assignments.items():
                     var_lines.append(f"LET {var} = {expression}")
@@ -583,7 +583,7 @@ class FilterSet:
         aql += f"    FILTER {self.doc_var}.{names.FLD_LOAD_VERSION} == @load_ver\n"
         if self.keep_filter_nulls:
             for i, k in enumerate(self.keep):
-                aql += f"    FILTER {self.doc_var}.@keep{i} != null\n"
+                aql += f"    FILTER {self.doc_var}[@keep{i}] != null\n"
                 bind_vars[f"keep{i}"] = k
         matchsel = f"{self.doc_var}.{names.FLD_MATCHES_SELECTIONS}"
         if self.match_spec.get_subset_filtering_id():
@@ -644,7 +644,7 @@ class FilterSet:
         if self.keep_filter_nulls:
             for i, k in enumerate(self.keep):
                 aql += f"        AND\n"
-                aql += f"        {self.doc_var}.@keep{i} != null\n"
+                aql += f"        {self.doc_var}[@keep{i}] != null\n"
                 bind_vars[f"keep{i}"] = k
         if self.match_spec.get_subset_filtering_id():
             bind_vars["internal_match_id"] = self.match_spec.get_subset_filtering_id()

--- a/test/src/service/filtering/filters_test.py
+++ b/test/src/service/filtering/filters_test.py
@@ -280,19 +280,19 @@ FOR doc IN @@view
         AND
         doc.load_ver == @load_ver
     ) AND (
-        IN_RANGE(doc.rangefield, @v1_low, @v1_high, true, true)
+        IN_RANGE(doc["rangefield"], @v1_low, @v1_high, true, true)
         AND
-        ANALYZER(STARTS_WITH(doc.prefixfield, v2_prefixes, LENGTH(v2_prefixes)), "text_en")
+        ANALYZER(STARTS_WITH(doc["prefixfield"], v2_prefixes, LENGTH(v2_prefixes)), "text_en")
         AND
-        doc.rangefield2 > @v3_low
+        doc["rangefield2"] > @v3_low
         AND
-        ANALYZER(v4_prefixes ALL == doc.fulltextfield, "text_rs")
+        ANALYZER(v4_prefixes ALL == doc["fulltextfield"], "text_rs")
         AND
-        doc.datefield <= @v5_high
+        doc["datefield"] <= @v5_high
         AND
-        NGRAM_MATCH(doc.ngramfield, @v6_input, 1, "ngram_stuff")
+        NGRAM_MATCH(doc["ngramfield"], @v6_input, 1, "ngram_stuff")
         AND
-        doc.strident == @v7_input
+        doc["strident"] == @v7_input
     )
     LIMIT @skip, @limit
     RETURN doc
@@ -351,19 +351,19 @@ RETURN COUNT(FOR doc IN @@view
         AND
         doc.load_ver == @load_ver
     ) AND (
-        IN_RANGE(doc.rangefield, @v1_low, @v1_high, true, true)
+        IN_RANGE(doc["rangefield"], @v1_low, @v1_high, true, true)
         AND
-        ANALYZER(STARTS_WITH(doc.prefixfield, v2_prefixes, LENGTH(v2_prefixes)), "text_en")
+        ANALYZER(STARTS_WITH(doc["prefixfield"], v2_prefixes, LENGTH(v2_prefixes)), "text_en")
         AND
-        doc.rangefield2 > @v3_low
+        doc["rangefield2"] > @v3_low
         AND
-        ANALYZER(v4_prefixes ALL == doc.fulltextfield, "text_rs")
+        ANALYZER(v4_prefixes ALL == doc["fulltextfield"], "text_rs")
         AND
-        doc.datefield <= @v5_high
+        doc["datefield"] <= @v5_high
         AND
-        NGRAM_MATCH(doc.ngramfield, @v6_input, 1, "ngram_stuff")
+        NGRAM_MATCH(doc["ngramfield"], @v6_input, 1, "ngram_stuff")
         AND
-        doc.strident == @v7_input
+        doc["strident"] == @v7_input
     )
     RETURN doc
 )
@@ -435,9 +435,9 @@ FOR d IN @@view
         AND
         d._mtchsel == @internal_selection_id
     ) AND (
-        IN_RANGE(d.rangefield, @v1_low, @v1_high, true, true)
+        IN_RANGE(d["rangefield"], @v1_low, @v1_high, true, true)
         OR
-        ANALYZER(STARTS_WITH(d.prefixfield, v2_prefixes, LENGTH(v2_prefixes)), "text_en")
+        ANALYZER(STARTS_WITH(d["prefixfield"], v2_prefixes, LENGTH(v2_prefixes)), "text_en")
     )
     SORT d.@sort @sortdir
     LIMIT @skip, @limit
@@ -479,11 +479,11 @@ FOR doc IN @@view
         AND
         doc.load_ver == @load_ver
         AND
-        doc.@keep0 != null
+        doc[@keep0] != null
         AND
-        doc.@keep1 != null
+        doc[@keep1] != null
     ) AND (
-        IN_RANGE(doc.rangefield, @v1_low, @v1_high, true, true)
+        IN_RANGE(doc["rangefield"], @v1_low, @v1_high, true, true)
     )
     LIMIT @skip, @limit
     RETURN KEEP(doc, @keep)
@@ -562,8 +562,8 @@ def test_filterset_aql_w_keep_filter():
 FOR doc IN @@collection
     FILTER doc.coll == @collid
     FILTER doc.load_ver == @load_ver
-    FILTER doc.@keep0 != null
-    FILTER doc.@keep1 != null
+    FILTER doc[@keep0] != null
+    FILTER doc[@keep1] != null
     LIMIT @skip, @limit
     RETURN KEEP(doc, @keep)
 """.strip() + "\n"
@@ -609,9 +609,9 @@ RETURN COUNT(FOR d IN @@view
         AND
         d._mtchsel == @internal_selection_id
     ) AND (
-        IN_RANGE(d.rangefield, @v1_low, @v1_high, true, true)
+        IN_RANGE(d["rangefield"], @v1_low, @v1_high, true, true)
         OR
-        ANALYZER(STARTS_WITH(d.prefixfield, v2_prefixes, LENGTH(v2_prefixes)), "text_en")
+        ANALYZER(STARTS_WITH(d["prefixfield"], v2_prefixes, LENGTH(v2_prefixes)), "text_en")
     )
     RETURN d
 )
@@ -683,7 +683,7 @@ FOR doc IN @@view
         AND
         doc.load_ver == @load_ver
     ) AND (
-        IN_RANGE(doc.rangefield, @v1_low, @v1_high, true, true)
+        IN_RANGE(doc["rangefield"], @v1_low, @v1_high, true, true)
     )
     SORT doc.@sort @sortdir
     LIMIT @skip, @limit
@@ -751,7 +751,7 @@ FOR doc IN @@view
         AND
         doc.load_ver == @load_ver
     ) AND (
-        IN_RANGE(doc.shoe_size, @v1_low, @v1_high, true, false)
+        IN_RANGE(doc["shoe_size"], @v1_low, @v1_high, true, false)
     )
     RETURN doc
 """.strip() + "\n"


### PR DESCRIPTION
The classic mistake of thinking since you control the fields you can just use dot notation. Nope, some sample fields have colons in them which borks things up.