### PR TITLE
RE2022-336: replace threads and program_threads in taskfarmer task generator

### DIFF
--- a/src/loaders/jobs/taskfarmer/task_generator.py
+++ b/src/loaders/jobs/taskfarmer/task_generator.py
@@ -50,7 +50,7 @@ TASKS_PER_NODE_DEFAULT = 1
 # Task metadata - tool specific parameters for task generation and execution
 # chunk_size is the quantity of genomes processed within each task (default is 5000)
 #    for batch genome tools, such as gtdb_tk and checkm2, the chunk_size specifies the number of genomes grouped
-#    together for processing in a batche by the tool
+#    together for processing in a batch by the tool
 #    for single genome tools, such as microtrait and mash, the chunk_size is the number of genomes to process in a
 #    serial manner
 # exe_time is the estimated execution time for a single task (default is 60 minutes)

--- a/src/loaders/jobs/taskfarmer/task_generator.py
+++ b/src/loaders/jobs/taskfarmer/task_generator.py
@@ -41,7 +41,7 @@ optional arguments:
 
 TOOLS_AVAILABLE = ['gtdb_tk', 'checkm2', 'microtrait', 'mash', 'eggnog']
 
-NODE_TIME_LIMIT_DEFAULT = 5  # hours  # TODO: automatically calculate this based on tool execution time and NODE_THREADS
+NODE_TIME_LIMIT_DEFAULT = 5  # hours
 # Used as THREADS variable in the batch script which controls the number of parallel tasks per node
 TASKS_PER_NODE_DEFAULT = 1
 


### PR DESCRIPTION
With the changes, current tool container will break until we update them (which should happen soon after this PR). 